### PR TITLE
Fix test for WebSocket being defined

### DIFF
--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -271,7 +271,7 @@ export class DirectLine implements IBotConnection {
         if (options.webSocket !== undefined)
             this.webSocket = options.webSocket;
 
-        this.activity$ = this.webSocket && WebSocket !== undefined
+        this.activity$ = this.webSocket && typeof WebSocket !== 'undefined' && WebSocket
             ? this.webSocketActivity$()
             : this.pollingGetActivity$();
     }


### PR DESCRIPTION
This fixes the initial problem.. but shouldn't WebSocket be an import, perhaps conditional on webSocket:true? It's not clear, as written, how WebSocket ends up in the global scope (by being imported by a different module perhaps?).