### PR TITLE
Imported "rxjs/add/observable/throw" to enable Observable.throw

### DIFF
--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -22,6 +22,7 @@ import 'rxjs/add/observable/empty';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/observable/interval';
 import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/throw';
 
 // Direct Line 3.0 types
 


### PR DESCRIPTION
When an error occurred (eg. token refresh fails because there is no internet connectivity), Observable.throw would get called, but then we get a javascript error because "throw" does not exist on Observable yet.

I had to import "rxjs/add/observable/throw" to get it to work.
