### PR TITLE
Support for resuming an existing conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,23 +142,52 @@ directLine.reconnect(conversation);
 
 ### Resume an existing conversation
 
-When using DirectLine with WebChat, closing the current tab or refreshing the page will create a new conversation in most cases.
+When using DirectLine with WebChat, closing the current tab or refreshing the page will create a new conversation in most cases. You can resume an existing conversation to keep the user in the same context.
 
-You can resume a conversation by:
-- Storing the conversationid and watermark (in a *permanent* place, like local storage)
-- Giving these values back while creating the DirectLine object
+**When using a secret** you can resume a conversation by:
+- Storing the conversationid (in a *permanent* place, like local storage)
+- Giving this value back while creating the DirectLine object along with the secret
 
 ```typescript
 import { DirectLine } from 'botframework-directlinejs';
 
 botConnection = new DirectLine({
-    secret: /* or token */,
-    conversationId: /* the conversationid you stored from previous conversation */,
-    watermark: /* the watermark you stored from previous conversation */,
+    secret: /* SECRET */,
+    conversationId: /* the conversationid you stored from previous conversation */
 });
 ```
 
-You can see the watermark as an *activity 'bookmark'*. The resuming scenario will ask to get all the conversation activities from the watermark you specify.
+**When using a token** you can resume a conversation by:
+- Storing the conversationid and your token (in a *permanent* place, like local storage)
+- Calling the DirectLine reconnect API yourself to get a refreshed token and a streamurl
+- Creating the DirectLine object using the ConversationId, Token, and StreamUrl
+
+```typescript
+import { DirectLine } from 'botframework-directlinejs';
+
+botConnection = new DirectLine({
+    token: /* the token you retrieved while reconnecting */,
+    streamUrl: /* the streamUrl you retrieved while reconnecting */,
+    conversationId: /* the conversationid you stored from previous conversation */
+});
+```
+
+**Getting history** : you can retrieve history using watermarks:
+You can see the watermark as an *activity 'bookmark'*. The resuming scenario will replay all the conversation activities from the watermark you specify. For now, this only works when using the polling version of DirectLine.
+
+```typescript
+import { DirectLine } from 'botframework-directlinejs';
+
+botConnection = new DirectLine({
+    token: /* the token you retrieved while reconnecting */,
+    streamUrl: /* the streamUrl you retrieved while reconnecting */,
+    conversationId: /* the conversationid you stored from previous conversation */,
+    watermark: /* a watermark you saved from a previous conversation */,
+    webSocket: false
+});
+```
+
+*Watermark with websocket will be supported in the future.*
 
 ## Copyright & License
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,24 @@ var conversation = /* a Conversation object obtained from your app's server */;
 directLine.reconnect(conversation);
 ```
 
+### Resume an existing conversation
+
+When using DirectLine with WebChat, closing the current tab or refreshing the page will create a new conversation in most cases.
+
+You can resume a conversation by:
+- Storing the conversationid and watermark (in a *permanent* place, like local storage)
+- Giving these values back while creating the DirectLine object
+
+```typescript
+botConnection = new DirectLine.DirectLine({
+    secret: /* or token */,
+    conversationId: /* the conversationid you stored from previous conversation */,
+    watermark: /* the watermark you stored from previous conversation */,
+});
+```
+
+You can see the watermark as an *activity 'bookmark'*. The resuming scenario will ask to get all the conversation activities from the watermark you specify.
+
 ## Copyright & License
 
 © 2017 Microsoft Corporation

--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ You can resume a conversation by:
 - Giving these values back while creating the DirectLine object
 
 ```typescript
-botConnection = new DirectLine.DirectLine({
+import { DirectLine } from 'botframework-directlinejs';
+
+botConnection = new DirectLine({
     secret: /* or token */,
     conversationId: /* the conversationid you stored from previous conversation */,
     watermark: /* the watermark you stored from previous conversation */,

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ When using DirectLine with WebChat, closing the current tab or refreshing the pa
 ```typescript
 import { DirectLine } from 'botframework-directlinejs';
 
-botConnection = new DirectLine({
+const dl = new DirectLine({
     secret: /* SECRET */,
     conversationId: /* the conversationid you stored from previous conversation */
 });
@@ -165,20 +165,20 @@ botConnection = new DirectLine({
 ```typescript
 import { DirectLine } from 'botframework-directlinejs';
 
-botConnection = new DirectLine({
+const dl = new DirectLine({
     token: /* the token you retrieved while reconnecting */,
     streamUrl: /* the streamUrl you retrieved while reconnecting */,
     conversationId: /* the conversationid you stored from previous conversation */
 });
 ```
 
-**Getting history** : you can retrieve history using watermarks:
+**Getting any history that Direct Line has cached** : you can retrieve history using watermarks:
 You can see the watermark as an *activity 'bookmark'*. The resuming scenario will replay all the conversation activities from the watermark you specify. For now, this only works when using the polling version of DirectLine.
 
 ```typescript
 import { DirectLine } from 'botframework-directlinejs';
 
-botConnection = new DirectLine({
+const dl = new DirectLine({
     token: /* the token you retrieved while reconnecting */,
     streamUrl: /* the streamUrl you retrieved while reconnecting */,
     conversationId: /* the conversationid you stored from previous conversation */,

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -219,8 +219,8 @@ export enum ConnectionStatus {
     ExpiredToken,               // last operation errored out with an expired token. Possibly waiting for someone to supply a new one.
     FailedToConnect,            // the initial attempt to connect to the conversation failed. No recovery possible.
     Ended,                      // the bot ended the conversation
-    Reconnect,
-    Reconnecting
+    Resume,
+    Resuming
 }
 
 export interface DirectLineOptions {
@@ -283,7 +283,7 @@ export class DirectLine implements IBotConnection {
         if(options.conversationId){
             this.conversationId = options.conversationId;
             if(options.watermark) this.watermark =  options.watermark;
-            this.connectionStatus$.next(ConnectionStatus.Reconnect);
+            this.connectionStatus$.next(ConnectionStatus.Resume);
         }
 
         if (options.pollingInterval !== undefined)
@@ -307,8 +307,8 @@ export class DirectLine implements IBotConnection {
                     this.connectionStatus$.next(ConnectionStatus.Connecting);
                     ajaxConversation = this.startConversation();
                     break;
-                case ConnectionStatus.Reconnect:
-                    this.connectionStatus$.next(ConnectionStatus.Reconnecting);
+                case ConnectionStatus.Resume:
+                    this.connectionStatus$.next(ConnectionStatus.Resuming);
                     ajaxConversation = this.startConversation(true);
                     break;
                 default:

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -275,21 +275,19 @@ export class DirectLine implements IBotConnection {
     constructor(options: DirectLineOptions) {
         this.secret = options.secret;
         this.token = options.secret || options.token;
-        this.webSocket = typeof WebSocket !== 'undefined' && WebSocket !== undefined; 
+        this.webSocket = (options.webSocket === undefined ? true : options.webSocket) && typeof WebSocket !== 'undefined' && WebSocket !== undefined; 
 
         if (options.domain)
             this.domain = options.domain;
-        if (options.webSocket !== undefined)
-            this.webSocket = this.webSocket && options.webSocket;
         if (options.conversationId) {
             this.conversationId = options.conversationId;
         }
-        if (options.watermark !== undefined) {
-                if (this.webSocket) 
-                    console.warn("Watermark was ignored: it is not supported using websockets at the moment");
-                else
-                    this.watermark =  options.watermark;
-            }
+        if (options.watermark) {
+            if (this.webSocket) 
+                console.warn("Watermark was ignored: it is not supported using websockets at the moment");
+            else
+                this.watermark =  options.watermark;
+        }
         if (options.streamUrl) {
             if (options.token && options.conversationId) 
                 this.streamUrl = options.streamUrl;
@@ -314,7 +312,7 @@ export class DirectLine implements IBotConnection {
                 this.connectionStatus$.next(ConnectionStatus.Connecting);
 
                 //if token and streamUrl are defined it means reconnect has already been done. Skipping it.
-                if (this.token !== undefined && this.streamUrl !== undefined) {
+                if (this.token && this.streamUrl) {
                     this.connectionStatus$.next(ConnectionStatus.Online);
                     return Observable.of(connectionStatus);
                 } else {

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -218,7 +218,7 @@ export enum ConnectionStatus {
     Online,                     // successfully connected to the converstaion. Connection is healthy so far as we know.
     ExpiredToken,               // last operation errored out with an expired token. Possibly waiting for someone to supply a new one.
     FailedToConnect,            // the initial attempt to connect to the conversation failed. No recovery possible.
-    Ended                      // the bot ended the conversation
+    Ended                       // the bot ended the conversation
 }
 
 export interface DirectLineOptions {
@@ -315,7 +315,7 @@ export class DirectLine implements IBotConnection {
             if (connectionStatus === ConnectionStatus.Uninitialized) {
                 this.connectionStatus$.next(ConnectionStatus.Connecting);
 
-                 //if token and streamUrl are defined it means reconnect has already been done. Skipping it.
+                //if token and streamUrl are defined it means reconnect has already been done. Skipping it.
                 if (this.token !== undefined && this.streamUrl !== undefined) {
                     this.connectionStatus$.next(ConnectionStatus.Online);
                     return Observable.of(connectionStatus);


### PR DESCRIPTION
**Edit on 3/28/17:** *I changed the code according to @billba feedbacks below. Now you can resume using token+conversationid+streamUrl OR conversationid+secret. You can optionally use watermark in both cases but only using the polling API for now. See updated readme for more details. Note that I used warnings to not fail silently when falling in an unsupported case.*

**Here is a impl. proposal for resuming a previously started conversation.**

**It is related to this related to issue #9 **

When creating a DirectLine object, you can now specify a **conversationid** and an *optional* **watermark** to resume previous conversation.

[Here is the readme update for more details](https://github.com/meulta/BotFramework-DirectLineJS/blob/e13432256408ed13d7debba42ad0b6d15f7cc886/README.md#resume-an-existing-conversation)