### PR TITLE
Rename object to Object

### DIFF
--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -199,7 +199,7 @@ export interface Message extends IActivity {
     suggestedActions?: { actions: CardAction[], to?: string[] },
     speak?: string,
     inputHint?: string,
-    value?: object
+    value?: Object
 }
 
 export interface Typing extends IActivity {


### PR DESCRIPTION
Using Typescript 2.3.2, hit the following error:
    Error - typescript - node_modules\botframework-directlinejs\built\directLine.d.ts(203,12): error TS2304: Cannot find name 'object'.

Found the [following issue](https://github.com/Microsoft/TypeScript/issues/14647) on the Typescript repo that suggested using uppercase O due to the object keyword in Typescript 2.2. Changing this certainly fixed in my scenario.