### PR TITLE
adding thumbnailUrl support in Meda

### DIFF
--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -40,7 +40,8 @@ export type MediaType = "image/png" | "image/jpg" | "image/jpeg" | "image/gif" |
 export interface Media {
     contentType: MediaType,
     contentUrl: string,
-    name?: string
+    name?: string,
+    thumbnailUrl?: string
 }
 
 export type CardActionTypes = "openUrl" | "imBack" | "postBack" | "playAudio" | "playVideo" | "showImage" | "downloadFile" | "signin" | "call";


### PR DESCRIPTION
Missing thumbnailUrl property from Media class.  This property is needed for video card to show thumbnail image before playing the audio.