### PR TITLE
export type KnownMedia

### DIFF
--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -175,7 +175,8 @@ export interface AnimationCard {
     }
 }
 
-export type Attachment = Media | UnknownMedia | HeroCard | Thumbnail | Signin | Receipt | AudioCard | VideoCard | AnimationCard | FlexCard | AdaptiveCard;
+export type KnownMedia = Media | HeroCard | Thumbnail | Signin | Receipt | AudioCard | VideoCard | AnimationCard | FlexCard | AdaptiveCard;
+export type Attachment = KnownMedia | UnknownMedia;
 
 export interface User {
     id: string,


### PR DESCRIPTION
In WebChat we had a [`switch` statement](https://github.com/Microsoft/BotFramework-WebChat/blob/28b00ca613cba50a9adaaf680e892ff611cdf096/src/Attachment.tsx#L161) which the TypeScript compiler could infer which subtype of Attachment each `case` referred to. With `UnknownMedia`'s `contentType: string`, the compiler could no longer infer.

So, adding a `KnownMedia`  type for the types with an explicit string value.