### PR TITLE
Added CardImage type

### DIFF
--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -60,13 +60,19 @@ export interface CardAction {
     image?: string
 }
 
+export interface CardImage {
+    alt?: string,
+    url: string,
+    tap?: CardAction
+}
+
 export interface HeroCard {
     contentType: "application/vnd.microsoft.card.hero",
     content: {
         title?: string,
         subtitle?: string,
         text?: string,
-        images?: { url: string }[],
+        images?: CardImage[],
         buttons?: CardAction[],
         tap?: CardAction
     }
@@ -78,7 +84,7 @@ export interface Thumbnail {
         title?: string,
         subtitle?: string,
         text?: string,
-        images?: { url: string }[],
+        images?: CardImage[],
         buttons?: CardAction[],
         tap?: CardAction
     }
@@ -96,7 +102,7 @@ export interface ReceiptItem {
     title?: string,
     subtitle?: string,
     text?: string,
-    image?: { url: string },
+    image?: CardImage,
     price?: string,
     quantity?: string,
     tap?: CardAction
@@ -123,7 +129,7 @@ export interface FlexCard {
         title?: string,
         subtitle?: string,
         text?: string,
-        images?: { url: string, tap?: CardAction }[],
+        images?: CardImage[],
         buttons?: CardAction[],
         aspect?: string
     }


### PR DESCRIPTION
Promotes image types to the new CardImage type which has additional properties as defined in the [API reference for Activity](https://docs.microsoft.com/en-us/bot-framework/rest-api/bot-framework-rest-connector-api-reference#activity-object) and the [swagger file](https://docs.botframework.com/en-us/restapi/directline3/swagger.json).