### PR TITLE
Adding OAuthCard, getSessionID and onPostActivity methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "description": "client library for the Microsoft Bot Framework Direct Line 3.0 protocol",
   "main": "built/directLine.js",
   "types": "built/directLine.d.ts",

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -287,7 +287,7 @@ export interface IBotConnection {
     end(): void,
     referenceGrammarId?: string,
     postActivity(activity: Activity): Observable<string>,
-    getSessionId(): Observable<string>
+    getSessionId? : () => Observable<string>
 }
 
 export class DirectLine implements IBotConnection {

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -288,15 +288,12 @@ export interface IBotConnection {
     end(): void,
     referenceGrammarId?: string,
     postActivity(activity: Activity): Observable<string>,
-    getSessionId(): Observable<string>,
-    onPostActivity: Observable<Activity>
+    getSessionId(): Observable<string>
 }
 
 export class DirectLine implements IBotConnection {
     public connectionStatus$ = new BehaviorSubject(ConnectionStatus.Uninitialized);
     public activity$: Observable<Activity>;
-    public onPostActivity: Observable<Activity>;
-    private onPostActivitySubject: Subject<Activity>;
 
     private domain = "https://directline.botframework.com/v3/directline";
     private webSocket;
@@ -316,9 +313,6 @@ export class DirectLine implements IBotConnection {
         this.secret = options.secret;
         this.token = options.secret || options.token;
         this.webSocket = (options.webSocket === undefined ? true : options.webSocket) && typeof WebSocket !== 'undefined' && WebSocket !== undefined; 
-
-        this.onPostActivitySubject = new Subject<Activity>();
-        this.onPostActivity = this.onPostActivitySubject.asObservable();
 
         if (options.domain)
             this.domain = options.domain;
@@ -509,8 +503,6 @@ export class DirectLine implements IBotConnection {
     }
 
     postActivity(activity: Activity) {
-        this.onPostActivitySubject.next(activity);
-
         // Use postMessageWithAttachments for messages with attachments that are local files (e.g. an image to upload)
         // Technically we could use it for *all* activities, but postActivity is much lighter weight
         // So, since WebChat is partially a reference implementation of Direct Line, we implement both.

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -98,6 +98,15 @@ export interface Signin {
     }
 }
 
+export interface OAuth {
+    contentType: "application/vnd.microsoft.card.oauth",
+    content: {
+        text?: string,
+        name: string,
+        buttons?: CardAction[]
+    }
+}
+
 export interface ReceiptItem {
     title?: string,
     subtitle?: string,
@@ -181,7 +190,7 @@ export interface AnimationCard {
     }
 }
 
-export type KnownMedia = Media | HeroCard | Thumbnail | Signin | Receipt | AudioCard | VideoCard | AnimationCard | FlexCard | AdaptiveCard;
+export type KnownMedia = Media | HeroCard | Thumbnail | Signin | OAuth | Receipt | AudioCard | VideoCard | AnimationCard | FlexCard | AdaptiveCard;
 export type Attachment = KnownMedia | UnknownMedia;
 
 export interface User {

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -2,7 +2,6 @@
 
 import { AjaxResponse, AjaxRequest } from 'rxjs/observable/dom/AjaxObservable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
 import { Subscriber } from 'rxjs/Subscriber';
 import { Subscription } from 'rxjs/Subscription';


### PR DESCRIPTION
This change introduces a number of things that are part of a set of authentication improvements for DirectLine and Azure Bot Service. These include:

1. The introduction of the OAuthCard, which is similar to the SignInCard but instead of requiring a login link in the card's buttons, it uses a ConnectionName that is resolved by DirectLine into the proper login link.
2. The addition of the getSessionId method, which is used by WebChat or other clients to add a secure cookie to the browser session that is used to guarantee that the recipient of the OAuthCard is the same as the person who has clicked on the button (avoids the magic code)
3. The addition of the onPostActivity observable which is called just prior to any Activity actually being sent to the bot. This is used so that subscribers can augment the outgoing Activities , such as to include a client side token in each outgoing message.