### PR TITLE
Add note about RxJS 6.* compatibility module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ If you're currently using WebChat, you don't need to make any changes as it incl
 
 Instead of callbacks or Promises, this library handles async operations using Observables. Try it, you'll like it! For more information, check out [RxJS](https://github.com/reactivex/rxjs/).
 
+> This library has been built upon RxJS 5.\* syntax. In order to get it working with RxJS 6.\*, please install RxJS `compat` module: `npm i rxjs-compat`
+
 ### *Can I use [TypeScript](http://www.typescriptlang.com)?*
 
 You bet.


### PR DESCRIPTION
Until the syntax is updated in library itself the `rxjs-compat` allows to successfully
use the library in other projects that use RxJS 6.*
The PR adds just a note to README.md for folks using the library in projects like Angular CLI scaffolded 6.*.

Thanks!