### PR TITLE
Better error handling for getSessionId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Add handling of 403/500 for `getSessionId`, in [#87](https://github.com/Microsoft/BotFramework-WebChat/pull/87)
+- Add handling of 403/500 for `getSessionId`, in [#87](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/87)
 
 ## [0.9.16] - 2018-08-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add handling of 403/500 for `getSessionId`, in [#87](https://github.com/Microsoft/BotFramework-WebChat/pull/87)
 
 ## [0.9.16] - 2018-08-14
 ### Added

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -496,10 +496,16 @@ export class DirectLine implements IBotConnection {
                     }
                 })
                 .map(ajaxResponse => {
-                    konsole.log("getSessionId response: " + ajaxResponse.response.sessionId);
-                    return ajaxResponse.response.sessionId as string;
+                    if (ajaxResponse && ajaxResponse.response && ajaxResponse.response.sessionId) {
+                        konsole.log("getSessionId response: " + ajaxResponse.response.sessionId);
+                        return ajaxResponse.response.sessionId as string;
+                    }
+                    return '';
                 })
-                .catch(error => this.catchPostError(error))
+                .catch(error => {
+                    konsole.log("getSessionId error: " + error.status);
+                    return Observable.of('');
+                })
             )
             .catch(error => this.catchExpiredToken(error));
     }


### PR DESCRIPTION
Adding better handling for the getSessionId call into DirectLine. This will handle 403/500 responses better as currently there is an issue where these sorts of errors can prevent WebChat from receiving further messages.