### PR TITLE
Watermark support for websocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support for watermark in Web Socket, in [#96](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/96)
 
 ## [0.9.17] - 2018-08-31
 ### Changed

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -322,10 +322,7 @@ export class DirectLine implements IBotConnection {
             this.conversationId = options.conversationId;
         }
         if (options.watermark) {
-            if (this.webSocket)
-                console.warn("Watermark was ignored: it is not supported using websockets at the moment");
-            else
-                this.watermark =  options.watermark;
+            this.watermark =  options.watermark;
         }
         if (options.streamUrl) {
             if (options.token && options.conversationId)

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -316,22 +316,29 @@ export class DirectLine implements IBotConnection {
         this.token = options.secret || options.token;
         this.webSocket = (options.webSocket === undefined ? true : options.webSocket) && typeof WebSocket !== 'undefined' && WebSocket !== undefined;
 
-        if (options.domain)
+        if (options.domain) {
             this.domain = options.domain;
+        }
+        
         if (options.conversationId) {
             this.conversationId = options.conversationId;
         }
+        
         if (options.watermark) {
             this.watermark =  options.watermark;
         }
+        
         if (options.streamUrl) {
-            if (options.token && options.conversationId)
+            if (options.token && options.conversationId) {
                 this.streamUrl = options.streamUrl;
-            else
-                console.warn("streamUrl was ignored: you need to provide a token and a conversationid");
+            } else {
+                console.warn('streamUrl was ignored: you need to provide a token and a conversationid');
+            }
         }
-        if (options.pollingInterval !== undefined)
+        
+        if (options.pollingInterval !== undefined) {
             this.pollingInterval = options.pollingInterval;
+        }
 
         this.activity$ = (this.webSocket
             ? this.webSocketActivity$()


### PR DESCRIPTION
Watermark must be forwarded to the server even in the case of websocket since the server now honors it.