### PR TITLE
Add a delay before retrying to connect to websocket. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add support for watermark in Web Socket, in [#96](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/96)
 
+### Changed
+- Delay before retrying Web Socket, in [#97](https://github.com/Microsoft/BotFramework-WebChat/pull/97)
+
 ## [0.9.17] - 2018-08-31
 ### Changed
 - Add handling of 403/500 for `getSessionId`, in [#87](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/87)

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -646,7 +646,7 @@ export class DirectLine implements IBotConnection {
             // WebSockets can be closed by the server or the browser. In the former case we need to
             // retrieve a new streamUrl. In the latter case we could first retry with the current streamUrl,
             // but it's simpler just to always fetch a new one.
-            .retryWhen(error$ => error$.mergeMap(error => this.reconnectToConversation()))
+            .retryWhen(error$ => error$.delay(3000).mergeMap(error => this.reconnectToConversation()))
         )
         .flatMap(activityGroup => this.observableFromActivityGroup(activityGroup))
     }


### PR DESCRIPTION
A delay of 3 seconds is chosen so that we hit the server less frequently for the case where
websocket connection is not going to succeed at all. At the same time
it is not too long for the cases when a reconnect succeeds - it will be
perceived as a transient glitch by the user since subsequent activities
would show up in time.