### PR TITLE
Error handling on connection issues

### DIFF
--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -279,7 +279,7 @@ const errorFailedToConnect = new Error("failed to connect");
 
 const konsole = {
     log: (message?: any, ... optionalParams: any[]) => {
-        if (typeof(window) !== 'undefined' && (window as any)["botchatDebug"] && message)
+        if (typeof window !== 'undefined' && (window as any)["botchatDebug"] && message)
             console.log(message, ... optionalParams);
     }
 }
@@ -319,15 +319,15 @@ export class DirectLine implements IBotConnection {
         if (options.domain) {
             this.domain = options.domain;
         }
-        
+
         if (options.conversationId) {
             this.conversationId = options.conversationId;
         }
-        
+
         if (options.watermark) {
             this.watermark =  options.watermark;
         }
-        
+
         if (options.streamUrl) {
             if (options.token && options.conversationId) {
                 this.streamUrl = options.streamUrl;
@@ -335,7 +335,7 @@ export class DirectLine implements IBotConnection {
                 console.warn('streamUrl was ignored: you need to provide a token and a conversationid');
             }
         }
-        
+
         if (options.pollingInterval !== undefined) {
             this.pollingInterval = options.pollingInterval;
         }
@@ -388,10 +388,10 @@ export class DirectLine implements IBotConnection {
                     return Observable.throw(errorFailedToConnect);
 
                 case ConnectionStatus.ExpiredToken:
-                    return Observable.of(connectionStatus);
+                    return Observable.throw(errorExpiredToken);
 
                 default:
-                    return Observable.of(connectionStatus);
+                    return Observable.of(null);
             }
         })
 
@@ -461,7 +461,11 @@ export class DirectLine implements IBotConnection {
                         // if the token is expired there's no reason to keep trying
                         this.expiredToken();
                         return Observable.throw(error);
+                    } else if (error.status === 404) {
+                        // If the bot is gone, we should stop retrying
+                        return Observable.throw(error);
                     }
+
                     return Observable.of(error);
                 })
                 .delay(timeout)
@@ -600,37 +604,51 @@ export class DirectLine implements IBotConnection {
     }
 
     private pollingGetActivity$() {
+        // Skip if the last request is still pending
+        let shouldSkip = false;
+
         return Observable.interval(this.pollingInterval)
         .combineLatest(this.checkConnection())
-        .flatMap(([_, connectionStatus]) => {
-            if (connectionStatus !== ConnectionStatus.Online)
-                return Observable.empty<Activity>()
+        .flatMap(() => {
+            if (shouldSkip) {
+                return Observable.empty<Activity>();
+            } else {
+                shouldSkip = true;
 
-            return Observable.ajax({
-                method: "GET",
-                url: `${this.domain}/conversations/${this.conversationId}/activities?watermark=${this.watermark}`,
-                timeout,
-                headers: {
-                    "Accept": "application/json",
-                    "Authorization": `Bearer ${this.token}`
-                }
-            })
-            .catch(error => {
-                if (error.status === 403) {
-                    // This is slightly ugly. We want to update this.connectionStatus$ to ExpiredToken so that subsequent
-                    // calls to checkConnection will throw an error. But when we do so, it causes this.checkConnection()
-                    // to immediately throw an error, which is caught by the catch() below and transformed into an empty
-                    // object. Then next() returns, and we emit an empty object. Which means one 403 is causing
-                    // two empty objects to be emitted. Which is harmless but, again, slightly ugly.
-                    this.expiredToken();
-                }
-                return Observable.empty<AjaxResponse>();
-            })
-//          .do(ajaxResponse => konsole.log("getActivityGroup ajaxResponse", ajaxResponse))
-            .map(ajaxResponse => ajaxResponse.response as ActivityGroup)
-            .flatMap(activityGroup => this.observableFromActivityGroup(activityGroup))
+                return Observable.ajax({
+                    method: "GET",
+                    url: `${this.domain}/conversations/${this.conversationId}/activities?watermark=${this.watermark}`,
+                    timeout,
+                    headers: {
+                        "Accept": "application/json",
+                        "Authorization": `Bearer ${this.token}`
+                    }
+                })
+                .do(() => {
+                    shouldSkip = false;
+                }, () => {
+                    shouldSkip = false;
+                })
+                .catch(error => {
+                    if (error.status === 403) {
+                        // This is slightly ugly. We want to update this.connectionStatus$ to ExpiredToken so that subsequent
+                        // calls to checkConnection will throw an error. But when we do so, it causes this.checkConnection()
+                        // to immediately throw an error, which is caught by the catch() below and transformed into an empty
+                        // object. Then next() returns, and we emit an empty object. Which means one 403 is causing
+                        // two empty objects to be emitted. Which is harmless but, again, slightly ugly.
+                        this.expiredToken();
+                    } else if (error.status === 404) {
+                        return Observable.throw(errorConversationEnded);
+                    }
+
+                    return Observable.empty<AjaxResponse>();
+                })
+    //          .do(ajaxResponse => konsole.log("getActivityGroup ajaxResponse", ajaxResponse))
+                .map(ajaxResponse => ajaxResponse.response as ActivityGroup)
+                .flatMap(activityGroup => this.observableFromActivityGroup(activityGroup))
+            }
         })
-        .catch(error => Observable.empty<Activity>());
+        .catch(() => Observable.empty<Activity>());
     }
 
     private observableFromActivityGroup(activityGroup: ActivityGroup) {
@@ -711,7 +729,10 @@ export class DirectLine implements IBotConnection {
                         // token has expired. We can't recover from this here, but the embedding
                         // website might eventually call reconnect() with a new token and streamUrl.
                         this.expiredToken();
+                    } else if (error.status === 404) {
+                        return Observable.throw(errorConversationEnded);
                     }
+
                     return Observable.of(error);
                 })
                 .delay(timeout)
@@ -719,5 +740,4 @@ export class DirectLine implements IBotConnection {
             )
         )
     }
-
 }


### PR DESCRIPTION
- Do not poll again if the existing poll did not complete yet
- Stop on expired token
   - User need to renew the token and restart a new conversation
- Stop on 404
   - If the bot is deleted, stop the connection and don't retry