### PR TITLE
Adds a configurable timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ var directLine = new DirectLine({
     domain: /* optional: if you are not using the default Direct Line endpoint, e.g. if you are using a region-specific endpoint, put its full URL here */
     webSocket: /* optional: false if you want to use polling GET to receive messages. Defaults to true (use WebSocket). */,
     pollingInterval: /* optional: set polling interval in milliseconds. Default to 1000 */,
+    timeout: /* optional: set post activity timeout in milliseconds. Default: 20000 */,
 });
 ```
 


### PR DESCRIPTION
This PR lets you configure the network / post activity timeout:

```javascript
var directLine = new DirectLine({
    timeout: /* put your timeout here (default is 20000 ms) */,
});
```

For example:
```javascript
var directLine = new DirectLine({
    timeout: 30000,
});
```

Rationale: Our app uses computer vision to handle attachments and we need to increase the timeout from 20 seconds to a greater number for these attachments where the bot sends these attachments to the CV service it could take a long time.

EDIT: As I learn more I believe I'm supposed to actually process the computer vision service call on a separate thread and respond immediately based on this:

> Bots are expected to respond with an acknowledgement (status 200) within 15 seconds. Something that can be done on channels that allow proactive messages is to process the incoming message on a separate thread, and acknowledge the call immediately.

Source Eric: https://github.com/Microsoft/BotBuilder/issues/3122#issuecomment-366387495