### PR TITLE
[do not merge - discussion] Richer errors and responses

### DIFF
--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -540,7 +540,7 @@ export class DirectLine implements IBotConnection {
                     "Authorization": `Bearer ${this.token}`
                 }
             })
-            .map(ajaxResponse => ajaxResponse.response.id as string)
+            .map(ajaxResponse => ajaxResponse as AjaxRequest)
             .catch(error => this.catchPostError(error))
         )
         .catch(error => this.catchExpiredToken(error));
@@ -581,7 +581,7 @@ export class DirectLine implements IBotConnection {
                     "Authorization": `Bearer ${this.token}`
                 }
             })
-            .map(ajaxResponse => ajaxResponse.response.id as string)
+            .map(ajaxResponse => ajaxResponse as AjaxRequest)
             .catch(error => this.catchPostError(error))
         )
         .catch(error => this.catchPostError(error));
@@ -594,7 +594,7 @@ export class DirectLine implements IBotConnection {
         else if (error.status >= 400 && error.status < 500)
             // more unrecoverable errors
             return Observable.throw(error);
-        return Observable.of("retry");
+        return Observable.of(error);
     }
 
     private catchExpiredToken(error: any) {


### PR DESCRIPTION
Hi @billba we use a fork of Directline in our app that gives us richer information about the response and error message instead of just the `id`. I was hoping if you could let us know if we are missing anything in our approach (given the diff and what's below). 😸 

```javascript
directLine.postActivity(activity).subscribe(response => {
   if (response.status === 200) {
      // success case ...
    } else {
      // consider retrying here
    }	      
});
```