### PR TITLE
Adds protection against user-given pollingInterval values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Adds protection against user-given pollingInterval values [#129](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/129)
+
 ## [0.10.2] - 2018-01-09
 - Added `messageBack` to `CardActionTypes` and updated `CardAction` fields, by [@corinagum](https://github.com/corinagum), in PR [#138](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/138)
 - Expand `CardAction`s with specific types, by [@corinagum](https://github.com/corinagum), in PR [#141](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/141)
-- Adds protection against user-given pollingInterval values [#129](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/129)
 
 ## [0.10.1] - 2018-12-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.10.2] - 2018-01-09
 - Added `messageBack` to `CardActionTypes` and updated `CardAction` fields, by [@corinagum](https://github.com/corinagum), in PR [#138](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/138)
 - Expand `CardAction`s with specific types, by [@corinagum](https://github.com/corinagum), in PR [#141](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/141)
+- Adds protection against user-given pollingInterval values [#129](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/129)
 
 ## [0.10.1] - 2018-12-21
 ### Changed
-
 - Prevents infinite WebSocket reconnection spam on subsequent token expiration signals [#127](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/127)
 
 ## [0.10.0] - 2018-10-30

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,5 +13,5 @@ module.exports = {
     "jsx",
     "json",
     "node"
-  ],
+  ]
 }

--- a/src/__tests__/directLine.test.ts
+++ b/src/__tests__/directLine.test.ts
@@ -3,17 +3,17 @@ import * as DirectLineExport from '../directLine';
 test('#setConnectionStatusFallback', () => {
     const { DirectLine } = DirectLineExport;
     expect(typeof DirectLine.prototype.setConnectionStatusFallback).toBe('function')
-    const { setConnectionStatusFallback } = DirectLine.prototype
-    const testFallback = setConnectionStatusFallback(0, 1)
-    let idx = 4
-    while(idx--) {
-      expect(testFallback(0)).toBe(0)
+    const { setConnectionStatusFallback } = DirectLine.prototype;
+    const testFallback = setConnectionStatusFallback(0, 1);
+    let idx = 4;
+    while (idx--) {
+      expect(testFallback(0)).toBe(0);
     }
     // fallback will be triggered
-    expect(testFallback(0)).toBe(1)
-    idx = 4
-    while(idx--) {
-        expect(testFallback(0)).toBe(0)
+    expect(testFallback(0)).toBe(1);
+    idx = 4;
+    while (idx--) {
+        expect(testFallback(0)).toBe(0);
     }
-    expect(testFallback(0)).toBe(1)
+    expect(testFallback(0)).toBe(1);
 });

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -387,7 +387,7 @@ export class DirectLine implements IBotConnection {
     public referenceGrammarId: string;
 
     private pollingInterval: number = 1000; //ms
-    private readonly POLLING_INTERVAL_LOWER_BOUND: number = 50; //ms
+    private readonly POLLING_INTERVAL_LOWER_BOUND: number = 200; //ms
 
     private tokenRefreshSubscription: Subscription;
 
@@ -412,13 +412,13 @@ export class DirectLine implements IBotConnection {
             if (options.token && options.conversationId) {
                 this.streamUrl = options.streamUrl;
             } else {
-                console.warn('streamUrl was ignored: you need to provide a token and a conversationid');
+                console.warn('DirectLineJS: streamUrl was ignored: you need to provide a token and a conversationid');
             }
         }
 
         if (options.pollingInterval !== undefined && typeof options.pollingInterval === 'number') {
             if (options.pollingInterval < this.POLLING_INTERVAL_LOWER_BOUND) {
-                console.warn('provided pollingInterval is under lower bound (200ms), using default of 1000ms');
+                console.warn('DirectLineJS: provided pollingInterval is under lower bound (200ms), using default of 1000ms');
             } else {
                 this.pollingInterval = options.pollingInterval;
             }
@@ -492,16 +492,14 @@ export class DirectLine implements IBotConnection {
         connectionStatusFrom: ConnectionStatus,
         connectionStatusTo: ConnectionStatus,
         maxAttempts = 5
-     ) {
+    ) {
         maxAttempts--;
         let attempts = 0;
         let currStatus = null;
         return (status: ConnectionStatus): ConnectionStatus => {
-            if (status === connectionStatusFrom && currStatus === status) {
-                if (attempts >= maxAttempts) {
-                    attempts = 0
-                    return connectionStatusTo;
-                }
+            if (status === connectionStatusFrom && currStatus === status && attempts >= maxAttempts) {
+                attempts = 0
+                return connectionStatusTo;
             }
             attempts++;
             currStatus = status;

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -416,7 +416,7 @@ export class DirectLine implements IBotConnection {
             }
         }
 
-        if (options.pollingInterval !== undefined && typeof options.pollingInterval === 'number') {
+        if (typeof options.pollingInterval === 'number') {
             if (options.pollingInterval < this.POLLING_INTERVAL_LOWER_BOUND) {
                 console.warn('DirectLineJS: provided pollingInterval is under lower bound (200ms), using default of 1000ms');
             } else {

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -386,7 +386,8 @@ export class DirectLine implements IBotConnection {
     private streamUrl: string;
     public referenceGrammarId: string;
 
-    private pollingInterval: number = 1000;
+    private pollingInterval: number = 1000; //ms
+    private readonly POLLING_INTERVAL_LOWER_BOUND: number = 50; //ms
 
     private tokenRefreshSubscription: Subscription;
 
@@ -415,8 +416,12 @@ export class DirectLine implements IBotConnection {
             }
         }
 
-        if (options.pollingInterval !== undefined) {
-            this.pollingInterval = options.pollingInterval;
+        if (options.pollingInterval !== undefined && typeof options.pollingInterval === 'number') {
+            if (options.pollingInterval < this.POLLING_INTERVAL_LOWER_BOUND) {
+                console.warn('provided pollingInterval is under lower bound (200ms), using default of 1000ms');
+            } else {
+                this.pollingInterval = options.pollingInterval;
+            }
         }
 
         this.expiredTokenExhaustion = this.setConnectionStatusFallback(

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -416,12 +416,11 @@ export class DirectLine implements IBotConnection {
                 console.warn('DirectLineJS: streamUrl was ignored: you need to provide a token and a conversationid');
             }
         }
-        
+
         const interval = Math.min(~~options.pollingInterval, POLLING_INTERVAL_LOWER_BOUND);
 
-        if (options.pollingInterval &&
-            Math.min(~~options.pollingInterval, POLLING_INTERVAL_LOWER_BOUND) < POLLING_INTERVAL_LOWER_BOUND) {
-            console.warn('DirectLineJS: provided pollingInterval is under lower bound (200ms), using default of 1000ms');
+        if (options.pollingInterval && interval < POLLING_INTERVAL_LOWER_BOUND) {
+            console.warn(`DirectLineJS: provided pollingInterval (${options.pollingInterval}) is under lower bound (200ms), using default of 1000ms`);
         } else {
             this.pollingInterval = options.pollingInterval;
         }


### PR DESCRIPTION
Currently a client can provide _any_ value for its `pollingInterval`, and when it happens to be a number, it can be arbitrary. This exposes both the DirectLineJS client library and the DirectLine API. One could specify a `pollingInterval` of 1ms and absolutely hammer the DirectLine API. We should prevent that.