### PR TITLE
Catch exceptions on empty send

### DIFF
--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -719,7 +719,13 @@ export class DirectLine implements IBotConnection {
                 // If we periodically ping the server with empty messages, it helps Chrome
                 // realize when connection breaks, and close the socket. We then throw an
                 // error, and that give us the opportunity to attempt to reconnect.
-                sub = Observable.interval(timeout).subscribe(_ => ws.send(""));
+                sub = Observable.interval(timeout).subscribe(_ => {
+                    try {
+                        ws.send("")
+                    } catch(e) {
+                        konsole.log("Ping error", e);
+                    }
+                });
             }
 
             ws.onclose = close => {


### PR DESCRIPTION
If the websocket is already disconnected, send throws an uncaught exception.

Trace:
```
AsyncScheduler.flush (AsyncScheduler.ts:44)
listOnTimeout (timers.js:324)
processTimers (timers.js:268)
[ Timeout ] (Unknown Source:undefined)
init (inspector_async_hook.js:27)
emitInitNative (async_hooks.js:137)
emitInitScript (async_hooks.js:336)
initAsyncResource (timers.js:52)
Timeout (timers.js:83)
setInterval (timers.js:502)
AsyncAction.requestAsyncId (AsyncAction.ts:74)
AsyncAction.schedule (AsyncAction.ts:68)
IntervalObservable.dispatch (IntervalObservable.ts:62)
AsyncAction._execute (AsyncAction.ts:123)
AsyncAction.execute (AsyncAction.ts:98)
AsyncScheduler.flush (AsyncScheduler.ts:33)
listOnTimeout (timers.js:324)
processTimers (timers.js:268)
[ Timeout ] (Unknown Source:undefined)
init (inspector_async_hook.js:27)
emitInitNative (async_hooks.js:137)
emitInitScript (async_hooks.js:336)
initAsyncResource (timers.js:52)
Timeout (timers.js:83)
setInterval (timers.js:502)
AsyncAction.requestAsyncId (AsyncAction.ts:74)
AsyncAction.schedule (AsyncAction.ts:68)
IntervalObservable.dispatch (IntervalObservable.ts:62)
AsyncAction._execute (AsyncAction.ts:123)
AsyncAction.execute (AsyncAction.ts:98)
AsyncScheduler.flush (AsyncScheduler.ts:33)
listOnTimeout (timers.js:324)
processTimers (timers.js:268)
[ Timeout ] (Unknown Source:undefined)
init (inspector_async_hook.js:27)
emitInitNative (async_hooks.js:137)
emitInitScript (async_hooks.js:336)
initAsyncResource (timers.js:52)
Timeout (timers.js:83)
setInterval (timers.js:502)
AsyncAction.requestAsyncId (AsyncAction.ts:74)
AsyncAction.schedule (AsyncAction.ts:68)
IntervalObservable.dispatch (IntervalObservable.ts:62)
AsyncAction._execute (AsyncAction.ts:123)
AsyncAction.execute (AsyncAction.ts:98)
AsyncScheduler.flush (AsyncScheduler.ts:33)
listOnTimeout (timers.js:324)
processTimers (timers.js:268)
[ Timeout ] (Unknown Source:undefined)
init (inspector_async_hook.js:27)
emitInitNative (async_hooks.js:137)
emitInitScript (async_hooks.js:336)
initAsyncResource (timers.js:52)
Timeout (timers.js:83)
setInterval (timers.js:502)
AsyncAction.requestAsyncId (AsyncAction.ts:74)
AsyncAction.schedule (AsyncAction.ts:68)
Scheduler.schedule (Scheduler.ts:61)
IntervalObservable._subscribe (IntervalObservable.ts:81)
Observable._trySubscribe (Observable.ts:217)
Observable.subscribe (Observable.ts:202)
ws.onopen (f:\Projects\Project\node_modules\botframework-directlinejs\src\directLine.ts:691)
onOpen (f:\Projects\Project\node_modules\ws\lib\event-target.js:132)
emit (events.js:182)
setSocket (f:\Projects\Project\node_modules\ws\lib\websocket.js:151)
req.on (f:\Projects\Project\node_modules\ws\lib\websocket.js:595)
emit (events.js:182)
socketOnData (_http_client.js:482)
emit (events.js:182)
addChunk (_stream_readable.js:283)
readableAddChunk (_stream_readable.js:264)
Readable.push (_stream_readable.js:219)
onStreamRead (stream_base_commons.js:122)
```