### PR TITLE
do not warn if polling interval is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -->
 
 ## [Unreleased]
+### Fixed
+- Fix [#160](https://github.com/Microsoft/BotFramework-DirectLineJS/issues/160). Removed warning if `pollingInterval` is `undefined`, by [@compulim](https://github.com/compulim) in PR [#161](https://github.com/Microosft/BotFramework-DirectLineJS/pull/161)
 
 ## [0.11.2] - 2019-02-05
 ### Fixed

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -438,7 +438,9 @@ export class DirectLine implements IBotConnection {
         const parsedPollingInterval = ~~options.pollingInterval;
 
         if (parsedPollingInterval < POLLING_INTERVAL_LOWER_BOUND) {
-            console.warn(`DirectLineJS: provided pollingInterval (${ options.pollingInterval }) is under lower bound (200ms), using default of 1000ms`);
+            if (typeof options.pollingInterval !== 'undefined') {
+                console.warn(`DirectLineJS: provided pollingInterval (${ options.pollingInterval }) is under lower bound (200ms), using default of 1000ms`);
+            }
         } else {
             this.pollingInterval = parsedPollingInterval;
         }


### PR DESCRIPTION
> Fix #160.

## Background

After our recent pull #157, a warning message will pop up if `pollingActivity` does not fall into our acceptable range and being overridden.

The warning message should not show up if the `pollingActivity` is `undefined`. This is because we should assume if the user provide `undefined` for an options, they prefer default value. Thus, the warning is redundant in this case.

This PR is to suppress the warning message for `undefined` case.

## Changelog

### Fixed
- Fix [#160](https://github.com/Microsoft/BotFramework-DirectLineJS/issues/160). Removed warning if `pollingInterval` is `undefined`, by [@compulim](https://github.com/compulim) in PR [#161](https://github.com/Microosft/BotFramework-DirectLineJS/pull/161)
