### PR TITLE
Do not log warn when polling interval is undefined

### DIFF
--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -435,12 +435,14 @@ export class DirectLine implements IBotConnection {
 
         this._botAgent = this.getBotAgent(options.botAgent);
 
-        const parsedPollingInterval = ~~options.pollingInterval;
+        if (options.pollingInterval !== undefined) {
+          const parsedPollingInterval = ~~options.pollingInterval;
 
-        if (parsedPollingInterval < POLLING_INTERVAL_LOWER_BOUND) {
-            console.warn(`DirectLineJS: provided pollingInterval (${ options.pollingInterval }) is under lower bound (200ms), using default of 1000ms`);
-        } else {
+          if (parsedPollingInterval < POLLING_INTERVAL_LOWER_BOUND) {
+            console.warn(`DirectLineJS: provided pollingInterval (${options.pollingInterval}) is under lower bound (200ms), using default of 1000ms`);
+          } else {
             this.pollingInterval = parsedPollingInterval;
+          }
         }
 
         this.expiredTokenExhaustion = this.setConnectionStatusFallback(


### PR DESCRIPTION
Silently use default `pollingInterval` when `pollingInterval` is not specified in `options` to avoid warning when users use WebSocket or just want to use default value on purpose.