### PR TITLE
Bump to 0.11.5-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.11.3] - 2019-03-01
+## [0.11.4] - 2019-03-04
 ### Changed
 - Change reconnect delay to be a random amount between 3s and 15s, by [@mingweiw](https://github.com/mingweiw) in PR [#164](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/164)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.11.4-0",
+  "version": "0.11.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.11.4",
+  "version": "0.11.5-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.11.4",
+  "version": "0.11.5-0",
   "description": "Client library for the Microsoft Bot Framework Direct Line 3.0 protocol",
   "files": [
     "built/**/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.11.4-0",
+  "version": "0.11.4",
   "description": "Client library for the Microsoft Bot Framework Direct Line 3.0 protocol",
   "files": [
     "built/**/*",


### PR DESCRIPTION
Since `0.11.3` was not published, due to NPM token issue. I have bumped the `CHANGELOG.md` to `0.11.4` to better reflect the actual published versions.