### PR TITLE
Handle websocket errors

### DIFF
--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -849,6 +849,12 @@ export class DirectLine implements IBotConnection {
 
             ws.onmessage = message => message.data && subscriber.next(JSON.parse(message.data));
 
+            ws.onerror = error =>  {
+                konsole.log("WebSocket error", error);
+                if (sub) sub.unsubscribe();
+                subscriber.error(error);
+            }
+
             // This is the 'unsubscribe' method, which is called when this observable is disposed.
             // When the WebSocket closes itself, we throw an error, and this function is eventually called.
             // When the observable is closed first (e.g. when tearing down a WebChat instance) then


### PR DESCRIPTION
This prevents unhandled exception on websocket errors.

It *doesn't* propagate the error, since the subscriber is internal,
and it doesn't seem to do anything with it (like notifying the
client via connectionStatus).

Bug: #170