### PR TITLE
Fix "prepublish" to "prepublishOnly" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ That said, the public API is still subject to change.
 
 0. Clone this repo
 1. `npm install`
-2. `npm run build` (or `npm run watch` to rebuild on every change, or `npm run prepublish` to build production)
+2. `npm run build` (or `npm run watch` to rebuild on every change, or `npm run prepublishOnly` to build production)
 
 ## How to include in your app
 


### PR DESCRIPTION
## Overview
- file : README.md
- change : prepublish -> prepublishOnly
- npm version : 6.1.0

## Detail
I executed "npm run prepublish" command according to README.md.
However, I got the following error.

```
> npm run prepublish
npm ERR! missing script: prepublish
```

Looking "[package.json](https://github.com/microsoft/BotFramework-DirectLineJS/blob/master/package.json)", the script is defined as "prepublishOnly".
When I executed "npm run prepublishOnly", I found that it works successfully.
So, I propose to fix README.md from prepublish to prepublishOnly.