### PR TITLE
Add metadata to upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    - [`webpack@4.39.3`](https://npmjs.com/package/webpack)
    - [`webpack-cli@3.3.8`](https://npmjs.com/package/webpack-cli)
 
+### Added
+- Fix [#235](https://github.com/Microsoft/BotFramework-DirectLineJS/issues/235). Fix Added metadata when uploading attachments, including `thumbnailUrl`, by [@compulim](https://github.com/compulim), in PR [#236](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/236)
+
 ## [0.11.4] - 2019-03-04
 ### Changed
 - Change reconnect delay to be a random amount between 3s and 15s, by [@mingweiw](https://github.com/mingweiw) in PR [#164](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/164)

--- a/src/dedupeFilenames.spec.js
+++ b/src/dedupeFilenames.spec.js
@@ -31,3 +31,9 @@ test('Deduping "Dockerfile", "Dockerfile"', () => {
 
   expect(actual).toEqual(['Dockerfile', 'Dockerfile (1)']);
 });
+
+test('Deduping "", ""', () => {
+  const actual = dedupeFilenames(['', '']);
+
+  expect(actual).toEqual(['', '(1)']);
+});

--- a/src/dedupeFilenames.spec.js
+++ b/src/dedupeFilenames.spec.js
@@ -1,0 +1,33 @@
+// @jest-environment node
+
+import dedupeFilenames from './dedupeFilenames';
+
+test('Deduping "abc.gif", "def.gif"', () => {
+  const actual = dedupeFilenames(['abc.gif', 'def.gif']);
+
+  expect(actual).toEqual(['abc.gif', 'def.gif']);
+});
+
+test('Deduping "abc.gif", "abc.gif"', () => {
+  const actual = dedupeFilenames(['abc.gif', 'abc.gif']);
+
+  expect(actual).toEqual(['abc.gif', 'abc (1).gif']);
+});
+
+test('Deduping "abc.def.gif", "abc.def.gif"', () => {
+  const actual = dedupeFilenames(['abc.def.gif', 'abc.def.gif']);
+
+  expect(actual).toEqual(['abc.def.gif', 'abc.def (1).gif']);
+});
+
+test('Deduping ".gitignore", ".gitignore"', () => {
+  const actual = dedupeFilenames(['.gitignore', '.gitignore']);
+
+  expect(actual).toEqual(['.gitignore', '(1).gitignore']);
+});
+
+test('Deduping "Dockerfile", "Dockerfile"', () => {
+  const actual = dedupeFilenames(['Dockerfile', 'Dockerfile']);
+
+  expect(actual).toEqual(['Dockerfile', 'Dockerfile (1)']);
+});

--- a/src/dedupeFilenames.ts
+++ b/src/dedupeFilenames.ts
@@ -1,0 +1,19 @@
+import parseFilename from './parseFilename';
+
+export default function dedupeFilenames(array: string[]) {
+    const nextArray: string[] = [];
+
+    array.forEach(value => {
+        let count = 0;
+        let nextValue = value;
+		const { extname, name } = parseFilename(value);
+
+        while (nextArray.includes(nextValue)) {
+            nextValue = [name, `(${ (++count) })`].filter(segment => segment).join(' ') + extname;
+        }
+
+        nextArray.push(nextValue);
+    });
+
+    return nextArray;
+}

--- a/src/dedupeFilenames.ts
+++ b/src/dedupeFilenames.ts
@@ -4,9 +4,9 @@ export default function dedupeFilenames(array: string[]) {
     const nextArray: string[] = [];
 
     array.forEach(value => {
+        const { extname, name } = parseFilename(value);
         let count = 0;
         let nextValue = value;
-		const { extname, name } = parseFilename(value);
 
         while (nextArray.includes(nextValue)) {
             nextValue = [name, `(${ (++count) })`].filter(segment => segment).join(' ') + extname;

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -25,6 +25,8 @@ import 'rxjs/add/observable/interval';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
 
+import dedupeFilenames from './dedupeFilenames';
+
 const DIRECT_LINE_VERSION = 'DirectLine/3.0';
 
 declare var process: {
@@ -685,7 +687,14 @@ export class DirectLine implements IBotConnection {
         .catch(error => this.catchExpiredToken(error));
     }
 
-    private postMessageWithAttachments({ attachments, ... messageWithoutAttachments }: Message) {
+    private postMessageWithAttachments(message: Message) {
+        const { attachments } = message;
+        // We clean the attachments but making sure every attachment has unique name
+        const attachmentNames: string[] = dedupeFilenames(attachments.map((media: Media) => media.name));
+        const cleansedAttachments = attachments.map((attachment: Media, index: number) => ({
+            ...attachment,
+            name: attachmentNames[index]
+        }));
         let formData: FormData;
 
         // If we're not connected to the bot, get connected
@@ -695,9 +704,13 @@ export class DirectLine implements IBotConnection {
             // To send this message to DirectLine we need to deconstruct it into a "template" activity
             // and one blob for each attachment.
             formData = new FormData();
-            formData.append('activity', new Blob([JSON.stringify(messageWithoutAttachments)], { type: 'application/vnd.microsoft.activity' }));
+            formData.append('activity', new Blob([JSON.stringify({
+                ...message,
+                // Removing contentUrl from attachment, we will send it via multipart
+                attachments: cleansedAttachments.map(({ contentUrl: string, ...others }) => ({ ...others }))
+            })], { type: 'application/vnd.microsoft.activity' }));
 
-            return Observable.from(attachments || [])
+            return Observable.from(cleansedAttachments)
             .flatMap((media: Media) =>
                 Observable.ajax({
                     method: "GET",
@@ -713,7 +726,7 @@ export class DirectLine implements IBotConnection {
         .flatMap(_ =>
             Observable.ajax({
                 method: "POST",
-                url: `${this.domain}/conversations/${this.conversationId}/upload?userId=${messageWithoutAttachments.from.id}`,
+                url: `${this.domain}/conversations/${this.conversationId}/upload?userId=${message.from.id}`,
                 body: formData,
                 timeout,
                 headers: {

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -689,8 +689,9 @@ export class DirectLine implements IBotConnection {
 
     private postMessageWithAttachments(message: Message) {
         const { attachments } = message;
-        // We clean the attachments but making sure every attachment has unique name
-        const attachmentNames: string[] = dedupeFilenames(attachments.map((media: Media) => media.name));
+        // We clean the attachments but making sure every attachment has unique name.
+        // If the file do not have a name, Chrome will assign "blob" when it is appended to FormData.
+        const attachmentNames: string[] = dedupeFilenames(attachments.map((media: Media) => media.name || 'blob'));
         const cleansedAttachments = attachments.map((attachment: Media, index: number) => ({
             ...attachment,
             name: attachmentNames[index]

--- a/src/parseFilename.js
+++ b/src/parseFilename.js
@@ -1,5 +1,10 @@
 export default function parseFilename(filename) {
-    if (~filename.indexOf('.')) {
+    if (!filename) {
+        return {
+            extname: '',
+            name: ''
+        };
+    } else if (~filename.indexOf('.')) {
         const [extensionWithoutDot, ...nameSegments] = filename.split('.').reverse();
 
         return {

--- a/src/parseFilename.js
+++ b/src/parseFilename.js
@@ -1,0 +1,15 @@
+export default function parseFilename(filename) {
+    if (~filename.indexOf('.')) {
+        const [extensionWithoutDot, ...nameSegments] = filename.split('.').reverse();
+
+        return {
+            extname: '.' + extensionWithoutDot,
+            name: nameSegments.reverse().join('.')
+        };
+    } else {
+        return {
+            extname: '',
+            name: filename
+        };
+    }
+}

--- a/src/parseFilename.spec.js
+++ b/src/parseFilename.spec.js
@@ -1,0 +1,32 @@
+// @jest-environment node
+
+import parseFilename from './parseFilename';
+
+test('Parsing "abc.gif"', () => {
+  const actual = parseFilename('abc.gif');
+
+  expect(actual).toHaveProperty('extname', '.gif');
+  expect(actual).toHaveProperty('name', 'abc');
+});
+
+test('Parsing "abc.def.gif"', () => {
+  const actual = parseFilename('abc.def.gif');
+
+  expect(actual).toHaveProperty('extname', '.gif');
+  expect(actual).toHaveProperty('name', 'abc.def');
+});
+
+test('Parsing ".gitignore"', () => {
+  const actual = parseFilename('.gitignore');
+
+  expect(actual).toHaveProperty('extname', '.gitignore');
+  expect(actual).toHaveProperty('name', '');
+});
+
+
+test('Parsing "Dockerfile"', () => {
+  const actual = parseFilename('Dockerfile');
+
+  expect(actual).toHaveProperty('extname', '');
+  expect(actual).toHaveProperty('name', 'Dockerfile');
+});

--- a/src/parseFilename.spec.js
+++ b/src/parseFilename.spec.js
@@ -23,10 +23,30 @@ test('Parsing ".gitignore"', () => {
   expect(actual).toHaveProperty('name', '');
 });
 
-
 test('Parsing "Dockerfile"', () => {
   const actual = parseFilename('Dockerfile');
 
   expect(actual).toHaveProperty('extname', '');
   expect(actual).toHaveProperty('name', 'Dockerfile');
+});
+
+test('Parsing null', () => {
+  const actual = parseFilename(null);
+
+  expect(actual).toHaveProperty('extname', '');
+  expect(actual).toHaveProperty('name', '');
+});
+
+test('Parsing undefined', () => {
+  const actual = parseFilename();
+
+  expect(actual).toHaveProperty('extname', '');
+  expect(actual).toHaveProperty('name', '');
+});
+
+test('Parsing ""', () => {
+  const actual = parseFilename('');
+
+  expect(actual).toHaveProperty('extname', '');
+  expect(actual).toHaveProperty('name', '');
 });


### PR DESCRIPTION
> Fix #235.

## Background

We recently updated our `/upload` endpoint to support metadata (e.g. `thumbnailUrl`) for attachments. The service work is carried out by @NickEricson and did not introduce backward compatibility issues.

This work is required for https://github.com/microsoft/BotFramework-WebChat/issues/2422.

## Changes

Instead of removing `activity.attachments`, we leave the `attachments` array but only removing `activity.attachments[].contentUrl`. This will send `contentType` and `thumbnailUrl` to the service.

The service will match metadata by looking at:
- `activity.attachments[].name`
- `filename` of multipart, where the multipart has `name` equals to `file`

### Quicklook

#### Today

```
-------boundary
Content-Disposition: form-data; name="activity"; filename="blob"
Content-Type: application/vnd.microsoft.activity

{
  "from": {
    "id": "dl_1234567"
  },
  "type": "message",
  ...
}
-------boundary
Content-Disposition: form-data; name="file"; filename="abc.png"
Content-Type: image/png

...
-------boundary
```

#### Tomorrow

```diff
  -------boundary
  Content-Disposition: form-data; name="activity"; filename="blob"
  Content-Type: application/vnd.microsoft.activity

  {
+   "attachments": [{
+     "contentType": "image/png",
+     "name": "abc.png",
+     "thumbnailUrl": "data:image/jpeg;base64,..."
+   }],
    "from": {
      "id": "dl_1234567"
    },
    "type": "message",
    ...
  }
  -------boundary
  Content-Disposition: form-data; name="file"; filename="abc.png"
  Content-Type: image/png

  ...
  -------boundary
```

> Note: the `filename` field on multipart is used for matching the corresponding item in the `attachments` array.

## Changelog

### Added

- Fix [#235](https://github.com/Microsoft/BotFramework-DirectLineJS/issues/235). Fix Added metadata when uploading attachments, including `thumbnailUrl`, by [@compulim](https://github.com/compulim), in PR [#236](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/236)