### PR TITLE
Bump transient dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3719,9 +3719,9 @@
       "dev": true
     },
     "csv-parse": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.4.5.tgz",
-      "integrity": "sha512-koPV9m9AjNJCK3ig4ErgRJalZsLxWI7NP0Fd3+CO9hgDZt3FSljTeESnfWTbyRc8qk/3/LgX1s5naDqLxiuK9w==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.4.6.tgz",
+      "integrity": "sha512-VisC5TBBhOF+70zjrF9FOiqI2LZOhXK/vAWlOrqyqz3lLa+P8jzJ7L/sg90MHmkSY/brAXWwrmGSZR0tM5yi4g==",
       "dev": true
     },
     "csv-stringify": {
@@ -5386,9 +5386,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.1.tgz",
+      "integrity": "sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",


### PR DESCRIPTION
Bumping transient dependencies after `npm audit`.

- `csv-parse@4.4.6` <- `csv` <- `restify`
- `handlebars@4.3.1` <- `istanbul-reports` <- `@jest/reporters` <- `@jest/core` <- `jest-cli` <- `jest`