### PR TITLE
reducing delay to 5 sec to address customer questions about perf and s…

### DIFF
--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -364,7 +364,7 @@ export interface DirectLineOptions {
 
 const lifetimeRefreshToken = 30 * 60 * 1000;
 const intervalRefreshToken = lifetimeRefreshToken / 2;
-const timeout = 20 * 1000;
+const timeout = 5 * 1000;
 const retries = (lifetimeRefreshToken - intervalRefreshToken) / timeout;
 
 const POLLING_INTERVAL_LOWER_BOUND: number = 200; //ms


### PR DESCRIPTION
reducing delay to 5 sec to address customer questions about perf and scale. 

This will allow client call to hit at least 2 times before DL 15 min impose timeout from the bot, providing the bot additional opportunities to respond to client requests. 