### PR TITLE
Bump to 0.11.7-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.11.6] - 2019-10-25
+
 ### Fixed
 
 - Reverting PR [#171](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/171) and PR [#172](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/172), which caused infinite loop of reconnections, by [@compulim](https://github.com/compulim) in PR [#240](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/240)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.11.6",
+  "version": "0.11.7-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.11.6-0",
+  "version": "0.11.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.11.6",
+  "version": "0.11.7-0",
   "description": "Client library for the Microsoft Bot Framework Direct Line 3.0 protocol",
   "files": [
     "dist/**/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.11.6-0",
+  "version": "0.11.6",
   "description": "Client library for the Microsoft Bot Framework Direct Line 3.0 protocol",
   "files": [
     "dist/**/*",


### PR DESCRIPTION
After we published `0.11.6`, this is for bumping to `0.11.7-0` (RC).