### PR TITLE
Debugging and throttling enhancements for directline-js

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -21,7 +21,13 @@ module.exports = {
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-proposal-object-rest-spread',
     '@babel/plugin-transform-runtime',
-    'babel-plugin-transform-inline-environment-variables'
+    [
+      "transform-inline-environment-variables", {
+        "include": [
+          "npm_package_version"
+        ]
+      }
+    ]
   ],
   presets: [
     ['@babel/preset-env', {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
   "files.trimTrailingWhitespace": true,
   "search.exclude": {
     "lib": true
-  }
+  },
+  "debug.node.autoAttach": "on"
 }

--- a/src/directLine.mock.ts
+++ b/src/directLine.mock.ts
@@ -3,6 +3,8 @@ import { TestScheduler, Observable } from "rxjs";
 import { AjaxCreationMethod, AjaxRequest, AjaxResponse } from "rxjs/observable/dom/AjaxObservable";
 import { URL, URLSearchParams } from 'url';
 
+export const mockActivity = (text: string): DirectLineExport.Activity => ({ type: 'message', from: { id: 'sender' }, text });
+
 interface ActivitySocket {
   play: (start: number, after: number) => void;
 }
@@ -30,7 +32,7 @@ const tokenResponse = (server: Server, request: AjaxRequest): AjaxResponse | nul
   return response as AjaxResponse;
 }
 
-const notImplemented = () => { throw new Error('not implemented') };
+const notImplemented = (): never => { throw new Error('not implemented') };
 
 const keyWatermark = 'watermark';
 

--- a/src/directLine.mock.ts
+++ b/src/directLine.mock.ts
@@ -91,7 +91,6 @@ export const mockAjax = (server: Server, customAjax?: ajaxType): AjaxCreationMet
       throw new Error();
     }
 
-    console.log(`${urlOrRequest.method}: ${urlOrRequest.url}`);
     const uri = new URL(urlOrRequest.url);
 
     const { pathname, searchParams } = uri;

--- a/src/directLine.mock.ts
+++ b/src/directLine.mock.ts
@@ -1,0 +1,244 @@
+import * as DirectLineExport from "./directLine";
+import { TestScheduler, Observable } from "rxjs";
+import { AjaxCreationMethod, AjaxRequest, AjaxResponse } from "rxjs/observable/dom/AjaxObservable";
+import { URL, URLSearchParams } from 'url';
+
+interface ActivitySocket {
+  play: (start: number, after: number) => void;
+}
+
+export type Socket = WebSocket & ActivitySocket;
+
+export interface Server {
+  scheduler: TestScheduler;
+  sockets: Set<WebSocket & ActivitySocket>;
+  conversation: Array<DirectLineExport.Activity>;
+  token: string;
+}
+
+const tokenResponse = (server: Server, request: AjaxRequest): AjaxResponse | null => {
+  const { headers } = request;
+  const authorization = headers['Authorization'];
+  if (authorization === `Bearer ${server.token}`) {
+      return null;
+  }
+
+  const response: Partial<AjaxResponse> = {
+      status: 403,
+  }
+
+  return response as AjaxResponse;
+}
+
+const notImplemented = () => { throw new Error('not implemented') };
+
+const keyWatermark = 'watermark';
+
+export const mockAjax = (server: Server): AjaxCreationMethod => {
+
+  const uriBase = new URL('https://directline.botframework.com/v3/directline/');
+  const createStreamUrl = (watermark: number): string => {
+      const uri = new URL('conversations/stream', uriBase);
+      if (watermark > 0) {
+          const params = new URLSearchParams();
+          params.append(keyWatermark, watermark.toString(10));
+          uri.search = params.toString();
+      }
+
+      return uri.toString();
+  }
+
+  const jax = (urlOrRequest: string | AjaxRequest): AjaxResponse => {
+      if (typeof urlOrRequest === 'string') {
+          throw new Error();
+      }
+
+      console.log(`${urlOrRequest.method}: ${urlOrRequest.url}`);
+      const uri = new URL(urlOrRequest.url);
+
+      const { pathname, searchParams } = uri;
+
+      const conversationId = 'SingleConversation';
+
+      const parts = pathname.split('/');
+
+      if (parts[3] === 'tokens' && parts[4] === 'refresh') {
+
+          const response: Partial<AjaxResponse> = {
+              response: { token: server.token }
+          };
+
+          return response as AjaxResponse;
+      }
+
+      if (parts[3] !== 'conversations') {
+          throw new Error();
+      }
+
+      if (parts.length === 4) {
+          const conversation: DirectLineExport.Conversation = {
+              conversationId,
+              token: server.token,
+              streamUrl: createStreamUrl(0),
+          };
+
+          const response: Partial<AjaxResponse> = {
+              response: conversation,
+          }
+
+          return response as AjaxResponse;
+      }
+
+      if (parts[4] !== conversationId) {
+          throw new Error();
+      }
+
+      if (parts[5] === 'activities') {
+          const responseToken = tokenResponse(server, urlOrRequest);
+          if (responseToken !== null) {
+              return responseToken;
+          }
+
+          const activity: DirectLineExport.Activity = urlOrRequest.body;
+
+          const after = server.conversation.push(activity);
+          const start = after - 1;
+
+          for (const socket of server.sockets) {
+              socket.play(start, after);
+          }
+
+          const response: Partial<AjaxResponse> = {
+              response: { id: 'messageId' },
+          }
+
+          return response as AjaxResponse;
+      }
+      else if (parts.length === 5) {
+          const responseToken = tokenResponse(server, urlOrRequest);
+          if (responseToken !== null) {
+              return responseToken;
+          }
+
+          const watermark = searchParams.get('watermark');
+          const start = Number.parseInt(watermark, 10);
+
+          const conversation: DirectLineExport.Conversation = {
+              conversationId,
+              token: server.token,
+              streamUrl: createStreamUrl(start),
+          };
+
+          const response: Partial<AjaxResponse> = {
+              response: conversation,
+          }
+
+          return response as AjaxResponse;
+      }
+
+      throw new Error();
+  };
+
+  const method = (urlOrRequest: string | AjaxRequest): Observable<AjaxResponse> =>
+      new Observable<AjaxResponse>(subscriber => {
+          try {
+              subscriber.next(jax(urlOrRequest));
+              subscriber.complete();
+          }
+          catch (error) {
+              subscriber.error(error);
+          }
+      });
+
+  type ValueType<T, V> = {
+      [K in keyof T]: T[K] extends V ? T[K] : never;
+  }
+
+  type Properties = ValueType<AjaxCreationMethod, Function>;
+
+  const properties: Properties = {
+      get: (url: string, headers?: Object): Observable<AjaxResponse> => notImplemented(),
+      post: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
+      put: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
+      patch: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
+      delete: (url: string, headers?: Object): Observable<AjaxResponse> => notImplemented(),
+      getJSON: (url: string, headers?: Object) => notImplemented(),
+  };
+
+  return Object.assign(method, properties);
+}
+
+type WebSocketConstructor = typeof WebSocket;
+type EventHandler<E extends Event> = (this: WebSocket, ev: E) => any;
+
+export const mockWebSocket = (server: Server): WebSocketConstructor =>
+  class MockWebSocket implements WebSocket, ActivitySocket {
+      constructor(url: string, protocols?: string | string[]) {
+          this.server = server;
+
+          server.scheduler.schedule(() => {
+              this.readyState = WebSocket.CONNECTING;
+              this.server.sockets.add(this);
+              this.onopen(new Event('open'));
+              this.readyState = WebSocket.OPEN;
+              const uri = new URL(url);
+              const watermark = uri.searchParams.get(keyWatermark)
+              if (watermark !== null) {
+                  const start = Number.parseInt(watermark, 10);
+                  this.play(start, this.server.conversation.length);
+              }
+          });
+      }
+
+      play(start: number, after: number) {
+
+          const { conversation } = this.server;
+          const activities = conversation.slice(start, after);
+          const watermark = conversation.length.toString();
+          const activityGroup: DirectLineExport.ActivityGroup = {
+              activities,
+              watermark,
+          }
+
+          const message = new MessageEvent('type', { data: JSON.stringify(activityGroup) });
+
+          this.onmessage(message);
+      }
+
+      private readonly server: Server;
+
+      binaryType: BinaryType = 'arraybuffer';
+      readonly bufferedAmount: number = 0;
+      readonly extensions: string = '';
+      readonly protocol: string = 'https';
+      readyState: number = WebSocket.CLOSED;
+      readonly url: string = '';
+      readonly CLOSED: number = WebSocket.CLOSED;
+      readonly CLOSING: number = WebSocket.CLOSING;
+      readonly CONNECTING: number = WebSocket.CONNECTING;
+      readonly OPEN: number = WebSocket.OPEN;
+
+      onclose: EventHandler<CloseEvent>;
+      onerror: EventHandler<Event>;
+      onmessage: EventHandler<MessageEvent>;
+      onopen: EventHandler<Event>;
+
+      close(code?: number, reason?: string): void {
+          this.readyState = WebSocket.CLOSING;
+          this.onclose(new CloseEvent('close'))
+          this.server.sockets.delete(this);
+          this.readyState = WebSocket.CLOSED;
+      }
+
+      send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
+      }
+
+      addEventListener() { throw new Error(); }
+      removeEventListener() { throw new Error(); }
+      dispatchEvent(): boolean { throw new Error(); }
+
+      static CLOSED = WebSocket.CLOSED;
+      static CLOSING = WebSocket.CLOSING;
+      static CONNECTING = WebSocket.CONNECTING;
+      static OPEN = WebSocket.OPEN;
+  };

--- a/src/directLine.mock.ts
+++ b/src/directLine.mock.ts
@@ -31,13 +31,15 @@ export interface Server {
   conversation: Conversation;
 }
 
+const tokenPrefix = 'token';
+
 export const mockServer = (scheduler: TestScheduler): Server => ({
   scheduler,
   conversation: {
     sockets: new Set<Socket>(),
     conversationId: 'OneConversation',
     history: [],
-    token: 'tokenA',
+    token: tokenPrefix + '1',
   }
 });
 
@@ -57,6 +59,12 @@ const tokenResponse = (server: Server, request: AjaxRequest): AjaxResponse | nul
 
 export const injectClose = (server: Server): void =>
   server.conversation.sockets.forEach(s => s.onclose(new CloseEvent('close')));
+
+export const injectNewToken = (server: Server): void => {
+  const { conversation } = server;
+  const suffix = Number.parseInt(conversation.token.substring(tokenPrefix.length), 10) + 1
+  conversation.token = tokenPrefix + suffix;
+}
 
 const keyWatermark = 'watermark';
 

--- a/src/directLine.mock.ts
+++ b/src/directLine.mock.ts
@@ -46,6 +46,9 @@ const tokenResponse = (server: Server, request: AjaxRequest): AjaxResponse | nul
   return response as AjaxResponse;
 }
 
+export const injectClose = (server: Server): void =>
+  server.sockets.forEach(s => s.onclose(new CloseEvent('close')));
+
 const notImplemented = (): never => { throw new Error('not implemented') };
 
 const keyWatermark = 'watermark';

--- a/src/directLine.mock.ts
+++ b/src/directLine.mock.ts
@@ -18,6 +18,13 @@ export interface Server {
   token: string;
 }
 
+export const mockServer = (scheduler: TestScheduler): Server => ({
+    scheduler,
+    sockets: new Set<Socket>(),
+    conversation: [],
+    token: 'tokenA',
+});
+
 const tokenResponse = (server: Server, request: AjaxRequest): AjaxResponse | null => {
   const { headers } = request;
   const authorization = headers['Authorization'];

--- a/src/directLine.mock.ts
+++ b/src/directLine.mock.ts
@@ -3,6 +3,13 @@ import { TestScheduler, Observable } from "rxjs";
 import { AjaxCreationMethod, AjaxRequest, AjaxResponse } from "rxjs/observable/dom/AjaxObservable";
 import { URL, URLSearchParams } from 'url';
 
+export const mockServices = (server: Server, scheduler: TestScheduler): DirectLineExport.Services => ({
+  scheduler,
+  WebSocket: mockWebSocket(server),
+  ajax: mockAjax(server),
+  random: () => 0,
+});
+
 export const mockActivity = (text: string): DirectLineExport.Activity => ({ type: 'message', from: { id: 'sender' }, text });
 
 interface ActivitySocket {
@@ -19,21 +26,21 @@ export interface Server {
 }
 
 export const mockServer = (scheduler: TestScheduler): Server => ({
-    scheduler,
-    sockets: new Set<Socket>(),
-    conversation: [],
-    token: 'tokenA',
+  scheduler,
+  sockets: new Set<Socket>(),
+  conversation: [],
+  token: 'tokenA',
 });
 
 const tokenResponse = (server: Server, request: AjaxRequest): AjaxResponse | null => {
   const { headers } = request;
   const authorization = headers['Authorization'];
   if (authorization === `Bearer ${server.token}`) {
-      return null;
+    return null;
   }
 
   const response: Partial<AjaxResponse> = {
-      status: 403,
+    status: 403,
   }
 
   return response as AjaxResponse;
@@ -47,131 +54,131 @@ export const mockAjax = (server: Server): AjaxCreationMethod => {
 
   const uriBase = new URL('https://directline.botframework.com/v3/directline/');
   const createStreamUrl = (watermark: number): string => {
-      const uri = new URL('conversations/stream', uriBase);
-      if (watermark > 0) {
-          const params = new URLSearchParams();
-          params.append(keyWatermark, watermark.toString(10));
-          uri.search = params.toString();
-      }
+    const uri = new URL('conversations/stream', uriBase);
+    if (watermark > 0) {
+      const params = new URLSearchParams();
+      params.append(keyWatermark, watermark.toString(10));
+      uri.search = params.toString();
+    }
 
-      return uri.toString();
+    return uri.toString();
   }
 
   const jax = (urlOrRequest: string | AjaxRequest): AjaxResponse => {
-      if (typeof urlOrRequest === 'string') {
-          throw new Error();
-      }
-
-      console.log(`${urlOrRequest.method}: ${urlOrRequest.url}`);
-      const uri = new URL(urlOrRequest.url);
-
-      const { pathname, searchParams } = uri;
-
-      const conversationId = 'SingleConversation';
-
-      const parts = pathname.split('/');
-
-      if (parts[3] === 'tokens' && parts[4] === 'refresh') {
-
-          const response: Partial<AjaxResponse> = {
-              response: { token: server.token }
-          };
-
-          return response as AjaxResponse;
-      }
-
-      if (parts[3] !== 'conversations') {
-          throw new Error();
-      }
-
-      if (parts.length === 4) {
-          const conversation: DirectLineExport.Conversation = {
-              conversationId,
-              token: server.token,
-              streamUrl: createStreamUrl(0),
-          };
-
-          const response: Partial<AjaxResponse> = {
-              response: conversation,
-          }
-
-          return response as AjaxResponse;
-      }
-
-      if (parts[4] !== conversationId) {
-          throw new Error();
-      }
-
-      if (parts[5] === 'activities') {
-          const responseToken = tokenResponse(server, urlOrRequest);
-          if (responseToken !== null) {
-              return responseToken;
-          }
-
-          const activity: DirectLineExport.Activity = urlOrRequest.body;
-
-          const after = server.conversation.push(activity);
-          const start = after - 1;
-
-          for (const socket of server.sockets) {
-              socket.play(start, after);
-          }
-
-          const response: Partial<AjaxResponse> = {
-              response: { id: 'messageId' },
-          }
-
-          return response as AjaxResponse;
-      }
-      else if (parts.length === 5) {
-          const responseToken = tokenResponse(server, urlOrRequest);
-          if (responseToken !== null) {
-              return responseToken;
-          }
-
-          const watermark = searchParams.get('watermark');
-          const start = Number.parseInt(watermark, 10);
-
-          const conversation: DirectLineExport.Conversation = {
-              conversationId,
-              token: server.token,
-              streamUrl: createStreamUrl(start),
-          };
-
-          const response: Partial<AjaxResponse> = {
-              response: conversation,
-          }
-
-          return response as AjaxResponse;
-      }
-
+    if (typeof urlOrRequest === 'string') {
       throw new Error();
+    }
+
+    console.log(`${urlOrRequest.method}: ${urlOrRequest.url}`);
+    const uri = new URL(urlOrRequest.url);
+
+    const { pathname, searchParams } = uri;
+
+    const conversationId = 'SingleConversation';
+
+    const parts = pathname.split('/');
+
+    if (parts[3] === 'tokens' && parts[4] === 'refresh') {
+
+      const response: Partial<AjaxResponse> = {
+        response: { token: server.token }
+      };
+
+      return response as AjaxResponse;
+    }
+
+    if (parts[3] !== 'conversations') {
+      throw new Error();
+    }
+
+    if (parts.length === 4) {
+      const conversation: DirectLineExport.Conversation = {
+        conversationId,
+        token: server.token,
+        streamUrl: createStreamUrl(0),
+      };
+
+      const response: Partial<AjaxResponse> = {
+        response: conversation,
+      }
+
+      return response as AjaxResponse;
+    }
+
+    if (parts[4] !== conversationId) {
+      throw new Error();
+    }
+
+    if (parts[5] === 'activities') {
+      const responseToken = tokenResponse(server, urlOrRequest);
+      if (responseToken !== null) {
+        return responseToken;
+      }
+
+      const activity: DirectLineExport.Activity = urlOrRequest.body;
+
+      const after = server.conversation.push(activity);
+      const start = after - 1;
+
+      for (const socket of server.sockets) {
+        socket.play(start, after);
+      }
+
+      const response: Partial<AjaxResponse> = {
+        response: { id: 'messageId' },
+      }
+
+      return response as AjaxResponse;
+    }
+    else if (parts.length === 5) {
+      const responseToken = tokenResponse(server, urlOrRequest);
+      if (responseToken !== null) {
+        return responseToken;
+      }
+
+      const watermark = searchParams.get('watermark');
+      const start = Number.parseInt(watermark, 10);
+
+      const conversation: DirectLineExport.Conversation = {
+        conversationId,
+        token: server.token,
+        streamUrl: createStreamUrl(start),
+      };
+
+      const response: Partial<AjaxResponse> = {
+        response: conversation,
+      }
+
+      return response as AjaxResponse;
+    }
+
+    throw new Error();
   };
 
   const method = (urlOrRequest: string | AjaxRequest): Observable<AjaxResponse> =>
-      new Observable<AjaxResponse>(subscriber => {
-          try {
-              subscriber.next(jax(urlOrRequest));
-              subscriber.complete();
-          }
-          catch (error) {
-              subscriber.error(error);
-          }
-      });
+    new Observable<AjaxResponse>(subscriber => {
+      try {
+        subscriber.next(jax(urlOrRequest));
+        subscriber.complete();
+      }
+      catch (error) {
+        subscriber.error(error);
+      }
+    });
 
   type ValueType<T, V> = {
-      [K in keyof T]: T[K] extends V ? T[K] : never;
+    [K in keyof T]: T[K] extends V ? T[K] : never;
   }
 
   type Properties = ValueType<AjaxCreationMethod, Function>;
 
   const properties: Properties = {
-      get: (url: string, headers?: Object): Observable<AjaxResponse> => notImplemented(),
-      post: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
-      put: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
-      patch: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
-      delete: (url: string, headers?: Object): Observable<AjaxResponse> => notImplemented(),
-      getJSON: (url: string, headers?: Object) => notImplemented(),
+    get: (url: string, headers?: Object): Observable<AjaxResponse> => notImplemented(),
+    post: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
+    put: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
+    patch: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
+    delete: (url: string, headers?: Object): Observable<AjaxResponse> => notImplemented(),
+    getJSON: (url: string, headers?: Object) => notImplemented(),
   };
 
   return Object.assign(method, properties);
@@ -182,72 +189,72 @@ type EventHandler<E extends Event> = (this: WebSocket, ev: E) => any;
 
 export const mockWebSocket = (server: Server): WebSocketConstructor =>
   class MockWebSocket implements WebSocket, ActivitySocket {
-      constructor(url: string, protocols?: string | string[]) {
-          this.server = server;
+    constructor(url: string, protocols?: string | string[]) {
+      this.server = server;
 
-          server.scheduler.schedule(() => {
-              this.readyState = WebSocket.CONNECTING;
-              this.server.sockets.add(this);
-              this.onopen(new Event('open'));
-              this.readyState = WebSocket.OPEN;
-              const uri = new URL(url);
-              const watermark = uri.searchParams.get(keyWatermark)
-              if (watermark !== null) {
-                  const start = Number.parseInt(watermark, 10);
-                  this.play(start, this.server.conversation.length);
-              }
-          });
+      server.scheduler.schedule(() => {
+        this.readyState = WebSocket.CONNECTING;
+        this.server.sockets.add(this);
+        this.onopen(new Event('open'));
+        this.readyState = WebSocket.OPEN;
+        const uri = new URL(url);
+        const watermark = uri.searchParams.get(keyWatermark)
+        if (watermark !== null) {
+          const start = Number.parseInt(watermark, 10);
+          this.play(start, this.server.conversation.length);
+        }
+      });
+    }
+
+    play(start: number, after: number) {
+
+      const { conversation } = this.server;
+      const activities = conversation.slice(start, after);
+      const watermark = conversation.length.toString();
+      const activityGroup: DirectLineExport.ActivityGroup = {
+        activities,
+        watermark,
       }
 
-      play(start: number, after: number) {
+      const message = new MessageEvent('type', { data: JSON.stringify(activityGroup) });
 
-          const { conversation } = this.server;
-          const activities = conversation.slice(start, after);
-          const watermark = conversation.length.toString();
-          const activityGroup: DirectLineExport.ActivityGroup = {
-              activities,
-              watermark,
-          }
+      this.onmessage(message);
+    }
 
-          const message = new MessageEvent('type', { data: JSON.stringify(activityGroup) });
+    private readonly server: Server;
 
-          this.onmessage(message);
-      }
+    binaryType: BinaryType = 'arraybuffer';
+    readonly bufferedAmount: number = 0;
+    readonly extensions: string = '';
+    readonly protocol: string = 'https';
+    readyState: number = WebSocket.CLOSED;
+    readonly url: string = '';
+    readonly CLOSED: number = WebSocket.CLOSED;
+    readonly CLOSING: number = WebSocket.CLOSING;
+    readonly CONNECTING: number = WebSocket.CONNECTING;
+    readonly OPEN: number = WebSocket.OPEN;
 
-      private readonly server: Server;
+    onclose: EventHandler<CloseEvent>;
+    onerror: EventHandler<Event>;
+    onmessage: EventHandler<MessageEvent>;
+    onopen: EventHandler<Event>;
 
-      binaryType: BinaryType = 'arraybuffer';
-      readonly bufferedAmount: number = 0;
-      readonly extensions: string = '';
-      readonly protocol: string = 'https';
-      readyState: number = WebSocket.CLOSED;
-      readonly url: string = '';
-      readonly CLOSED: number = WebSocket.CLOSED;
-      readonly CLOSING: number = WebSocket.CLOSING;
-      readonly CONNECTING: number = WebSocket.CONNECTING;
-      readonly OPEN: number = WebSocket.OPEN;
+    close(code?: number, reason?: string): void {
+      this.readyState = WebSocket.CLOSING;
+      this.onclose(new CloseEvent('close'))
+      this.server.sockets.delete(this);
+      this.readyState = WebSocket.CLOSED;
+    }
 
-      onclose: EventHandler<CloseEvent>;
-      onerror: EventHandler<Event>;
-      onmessage: EventHandler<MessageEvent>;
-      onopen: EventHandler<Event>;
+    send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
+    }
 
-      close(code?: number, reason?: string): void {
-          this.readyState = WebSocket.CLOSING;
-          this.onclose(new CloseEvent('close'))
-          this.server.sockets.delete(this);
-          this.readyState = WebSocket.CLOSED;
-      }
+    addEventListener() { throw new Error(); }
+    removeEventListener() { throw new Error(); }
+    dispatchEvent(): boolean { throw new Error(); }
 
-      send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
-      }
-
-      addEventListener() { throw new Error(); }
-      removeEventListener() { throw new Error(); }
-      dispatchEvent(): boolean { throw new Error(); }
-
-      static CLOSED = WebSocket.CLOSED;
-      static CLOSING = WebSocket.CLOSING;
-      static CONNECTING = WebSocket.CONNECTING;
-      static OPEN = WebSocket.OPEN;
+    static CLOSED = WebSocket.CLOSED;
+    static CLOSING = WebSocket.CLOSING;
+    static CONNECTING = WebSocket.CONNECTING;
+    static OPEN = WebSocket.OPEN;
   };

--- a/src/directLine.mock.ts
+++ b/src/directLine.mock.ts
@@ -68,9 +68,11 @@ export const injectNewToken = (server: Server): void => {
 
 const keyWatermark = 'watermark';
 
+type ajaxType = (urlOrRequest: string | AjaxRequest) => AjaxResponse;
+
 // MOCK Observable.ajax (uses shared state in Server)
 
-export const mockAjax = (server: Server): AjaxCreationMethod => {
+export const mockAjax = (server: Server, customAjax?: ajaxType): AjaxCreationMethod => {
 
   const uriBase = new URL('https://directline.botframework.com/v3/directline/');
   const createStreamUrl = (watermark: number): string => {
@@ -84,7 +86,7 @@ export const mockAjax = (server: Server): AjaxCreationMethod => {
     return uri.toString();
   }
 
-  const jax = (urlOrRequest: string | AjaxRequest): AjaxResponse => {
+  const jax = customAjax || ((urlOrRequest: string | AjaxRequest): AjaxResponse => {
     if (typeof urlOrRequest === 'string') {
       throw new Error();
     }
@@ -171,7 +173,7 @@ export const mockAjax = (server: Server): AjaxCreationMethod => {
     }
 
     throw new Error();
-  };
+  });
 
   const method = (urlOrRequest: string | AjaxRequest): Observable<AjaxResponse> =>
     new Observable<AjaxResponse>(subscriber => {

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -82,11 +82,9 @@ test('TestWithMocks', () => {
         token: 'tokenA',
     };
 
-    const makeActivity = (text: string): DirectLineExport.Activity => ({ type: 'message', from: { id: 'sender' }, text });
-
     const expected = {
-        x: makeActivity('x'),
-        y: makeActivity('y'),
+        x: DirectLineMock.mockActivity('x'),
+        y: DirectLineMock.mockActivity('y'),
     };
 
     // arrange

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -218,7 +218,7 @@ describe("MockSuite", () => {
 
         const scenario = function* (): IterableIterator<Observable<unknown>> {
             yield Observable.timer(200, scheduler);
-            yield directline.postActivity(expected.x);
+            yield directline.postActivity(expected.x).catch(() => Observable.empty(scheduler));
         };
 
         subscriptions.push(lazyConcat(scenario()).observeOn(scheduler).subscribe());

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -221,6 +221,9 @@ describe("MockSuite", () => {
             yield directline.postActivity(expected.x).catch(() => Observable.empty(scheduler));
         };
 
+        // lack of subscribe arguments means that the empty subscriber is used
+        // the empty subscriber will propagate observable errors on the JS call stack
+        // within the scheduler notification action handling loop because of the observeOn
         subscriptions.push(lazyConcat(scenario()).observeOn(scheduler).subscribe());
         scheduler.flush();
 

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -86,12 +86,7 @@ describe("MockSuite", () => {
 
         // arrange
 
-        const options: DirectLineExport.Services = {
-            scheduler,
-            WebSocket: DirectLineMock.mockWebSocket(server),
-            ajax: DirectLineMock.mockAjax(server),
-            random: () => 0,
-        };
+        const options = DirectLineMock.mockServices(server, scheduler);
 
         const directline = new DirectLine(options);
 

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -311,6 +311,7 @@ test('TestWithMocks', () => {
         scheduler,
         WebSocket: mockWebSocket(server),
         ajax: mockAjax(server),
+        random: () => 0,
     };
 
     const directline = new DirectLine(options);

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -72,15 +72,20 @@ describe("MockSuite", () => {
             let inner: Subscription | undefined;
 
             const pump = () => {
-                const result = iterator.next();
-                if (result.done === true) {
-                    subscriber.complete();
+                try {
+                    const result = iterator.next();
+                    if (result.done === true) {
+                        subscriber.complete();
+                    }
+                    else {
+                        inner = result.value.subscribe(
+                            value => subscriber.next(value),
+                            error => subscriber.error(error),
+                            pump);
+                    }
                 }
-                else {
-                    inner = result.value.subscribe(
-                        value => subscriber.next(value),
-                        error => subscriber.error(error),
-                        pump);
+                catch (error) {
+                    subscriber.error(error);
                 }
             };
 

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -95,7 +95,7 @@ describe('MockSuite', () => {
             pump();
 
             return () => {
-                if (inner !== undefined) {
+                if (typeof inner !== 'undefined') {
                     inner.unsubscribe();
                 }
             };

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -127,7 +127,7 @@ describe("MockSuite", () => {
             const scenario = function* (): IterableIterator<Observable<unknown>> {
                 yield Observable.timer(200, scheduler);
                 yield directline.postActivity(expected.x);
-                server.sockets.forEach(s => s.onclose(new CloseEvent('close')));
+                DirectLineMock.injectClose(server);
                 yield Observable.timer(200, scheduler);
                 yield directline.postActivity(expected.y);
                 yield Observable.timer(200, scheduler);

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -78,8 +78,8 @@ const mockAjax = (server: MockServer): AjaxCreationMethod => {
 
     const jax = (urlOrRequest: string | AjaxRequest): AjaxResponse => {
         if (typeof urlOrRequest !== 'string') {
-            const { url } = urlOrRequest;
-            console.log(url);
+            const { method, url } = urlOrRequest;
+            console.log(`${method}: ${url}`);
             const parts = url.split(/[\/\?]/);
             if (parts[5] === 'conversations') {
                 if (parts[7] === 'activities') {

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -1,6 +1,8 @@
 import * as DirectLineExport from "./directLine";
 import * as DirectLineMock from './directLine.mock';
 import { TestScheduler, Observable, Subscription } from "rxjs";
+//@ts-ignore
+import {version} from "../package.json";
 
 declare var process: {
     arch: string;
@@ -175,4 +177,12 @@ describe("MockSuite", () => {
 
         expect(actual).toStrictEqual([expected.x, expected.y]);
     });
+
+    test('BotAgentWithMocks', () => {
+        const expected: string = `DirectLine/3.0 (directlinejs ${version})`;
+
+        //@ts-ignore
+        const actual: string = directline.commonHeaders()["x-ms-bot-agent"];
+        expect(actual).toStrictEqual(expected)
+    })
 });

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -1,9 +1,6 @@
 import * as DirectLineExport from "./directLine";
+import * as DirectLineMock from './directLine.mock';
 import { TestScheduler, Observable, Subscription } from "rxjs";
-import { AjaxCreationMethod, AjaxRequest, AjaxResponse } from "rxjs/observable/dom/AjaxObservable";
-import { IScheduler } from "rxjs/Scheduler";
-import { Action } from "rxjs/scheduler/Action";
-import { URL, URLSearchParams } from 'url';
 
 declare var process: {
     arch: string;
@@ -67,244 +64,6 @@ describe("#commonHeaders", () => {
     })
 });
 
-interface ActivitySocket {
-    play: (start: number, after: number) => void;
-}
-
-interface MockServer {
-    scheduler: TestScheduler;
-    sockets: Set<WebSocket & ActivitySocket>;
-    conversation: Array<DirectLineExport.Activity>;
-    token: string;
-}
-
-const tokenResponse = (server: MockServer, request: AjaxRequest): AjaxResponse | null => {
-    const { headers } = request;
-    const authorization = headers['Authorization'];
-    if (authorization === `Bearer ${server.token}`) {
-        return null;
-    }
-
-    const response: Partial<AjaxResponse> = {
-        status: 403,
-    }
-
-    return response as AjaxResponse;
-}
-
-const notImplemented = () => { throw new Error('not implemented') };
-
-const keyWatermark = 'watermark';
-
-const mockAjax = (server: MockServer): AjaxCreationMethod => {
-
-    const uriBase = new URL('https://directline.botframework.com/v3/directline/');
-    const createStreamUrl = (watermark: number): string => {
-        const uri = new URL('conversations/stream', uriBase);
-        if (watermark > 0) {
-            const params = new URLSearchParams();
-            params.append(keyWatermark, watermark.toString(10));
-            uri.search = params.toString();
-        }
-
-        return uri.toString();
-    }
-
-    const jax = (urlOrRequest: string | AjaxRequest): AjaxResponse => {
-        if (typeof urlOrRequest === 'string') {
-            throw new Error();
-        }
-
-        console.log(`${urlOrRequest.method}: ${urlOrRequest.url}`);
-        const uri = new URL(urlOrRequest.url);
-
-        const { pathname, searchParams } = uri;
-
-        const conversationId = 'SingleConversation';
-
-        const parts = pathname.split('/');
-
-        if (parts[3] === 'tokens' && parts[4] === 'refresh') {
-
-            const response: Partial<AjaxResponse> = {
-                response: { token: server.token }
-            };
-
-            return response as AjaxResponse;
-        }
-
-        if (parts[3] !== 'conversations') {
-            throw new Error();
-        }
-
-        if (parts.length === 4) {
-            const conversation: DirectLineExport.Conversation = {
-                conversationId,
-                token: server.token,
-                streamUrl: createStreamUrl(0),
-            };
-
-            const response: Partial<AjaxResponse> = {
-                response: conversation,
-            }
-
-            return response as AjaxResponse;
-        }
-
-        if (parts[4] !== conversationId) {
-            throw new Error();
-        }
-
-        if (parts[5] === 'activities') {
-            const responseToken = tokenResponse(server, urlOrRequest);
-            if (responseToken !== null) {
-                return responseToken;
-            }
-
-            const activity: DirectLineExport.Activity = urlOrRequest.body;
-
-            const after = server.conversation.push(activity);
-            const start = after - 1;
-
-            for (const socket of server.sockets) {
-                socket.play(start, after);
-            }
-
-            const response: Partial<AjaxResponse> = {
-                response: { id: 'messageId' },
-            }
-
-            return response as AjaxResponse;
-        }
-        else if (parts.length === 5) {
-            const responseToken = tokenResponse(server, urlOrRequest);
-            if (responseToken !== null) {
-                return responseToken;
-            }
-
-            const watermark = searchParams.get('watermark');
-            const start = Number.parseInt(watermark, 10);
-
-            const conversation: DirectLineExport.Conversation = {
-                conversationId,
-                token: server.token,
-                streamUrl: createStreamUrl(start),
-            };
-
-            const response: Partial<AjaxResponse> = {
-                response: conversation,
-            }
-
-            return response as AjaxResponse;
-        }
-
-        throw new Error();
-    };
-
-    const method = (urlOrRequest: string | AjaxRequest): Observable<AjaxResponse> =>
-        new Observable<AjaxResponse>(subscriber => {
-            try {
-                subscriber.next(jax(urlOrRequest));
-                subscriber.complete();
-            }
-            catch (error) {
-                subscriber.error(error);
-            }
-        });
-
-    type ValueType<T, V> = {
-        [K in keyof T]: T[K] extends V ? T[K] : never;
-    }
-
-    type Properties = ValueType<AjaxCreationMethod, Function>;
-
-    const properties: Properties = {
-        get: (url: string, headers?: Object): Observable<AjaxResponse> => notImplemented(),
-        post: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
-        put: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
-        patch: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
-        delete: (url: string, headers?: Object): Observable<AjaxResponse> => notImplemented(),
-        getJSON: (url: string, headers?: Object) => notImplemented(),
-    };
-
-    return Object.assign(method, properties);
-}
-
-type WebSocketConstructor = typeof WebSocket;
-type EventHandler<E extends Event> = (this: WebSocket, ev: E) => any;
-
-const mockWebSocket = (server: MockServer): WebSocketConstructor =>
-    class MockWebSocket implements WebSocket, ActivitySocket {
-        constructor(url: string, protocols?: string | string[]) {
-            this.server = server;
-
-            server.scheduler.schedule(() => {
-                this.readyState = WebSocket.CONNECTING;
-                this.server.sockets.add(this);
-                this.onopen(new Event('open'));
-                this.readyState = WebSocket.OPEN;
-                const uri = new URL(url);
-                const watermark = uri.searchParams.get(keyWatermark)
-                if (watermark !== null) {
-                    const start = Number.parseInt(watermark, 10);
-                    this.play(start, this.server.conversation.length);
-                }
-            });
-        }
-
-        play(start: number, after: number) {
-
-            const { conversation } = this.server;
-            const activities = conversation.slice(start, after);
-            const watermark = conversation.length.toString();
-            const activityGroup: DirectLineExport.ActivityGroup = {
-                activities,
-                watermark,
-            }
-
-            const message = new MessageEvent('type', { data: JSON.stringify(activityGroup) });
-
-            this.onmessage(message);
-        }
-
-        private readonly server: MockServer;
-
-        binaryType: BinaryType = 'arraybuffer';
-        readonly bufferedAmount: number = 0;
-        readonly extensions: string = '';
-        readonly protocol: string = 'https';
-        readyState: number = WebSocket.CLOSED;
-        readonly url: string = '';
-        readonly CLOSED: number = WebSocket.CLOSED;
-        readonly CLOSING: number = WebSocket.CLOSING;
-        readonly CONNECTING: number = WebSocket.CONNECTING;
-        readonly OPEN: number = WebSocket.OPEN;
-
-        onclose: EventHandler<CloseEvent>;
-        onerror: EventHandler<Event>;
-        onmessage: EventHandler<MessageEvent>;
-        onopen: EventHandler<Event>;
-
-        close(code?: number, reason?: string): void {
-            this.readyState = WebSocket.CLOSING;
-            this.onclose(new CloseEvent('close'))
-            this.server.sockets.delete(this);
-            this.readyState = WebSocket.CLOSED;
-        }
-
-        send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
-        }
-
-        addEventListener() { throw new Error(); }
-        removeEventListener() { throw new Error(); }
-        dispatchEvent(): boolean { throw new Error(); }
-
-        static CLOSED = WebSocket.CLOSED;
-        static CLOSING = WebSocket.CLOSING;
-        static CONNECTING = WebSocket.CONNECTING;
-        static OPEN = WebSocket.OPEN;
-    };
-
 test('TestWithMocks', () => {
 
     const { DirectLine } = DirectLineExport;
@@ -316,9 +75,9 @@ test('TestWithMocks', () => {
 
     scheduler.maxFrames = 60 * 1000;
 
-    const server: MockServer = {
+    const server: DirectLineMock.Server = {
         scheduler,
-        sockets: new Set<WebSocket & ActivitySocket>(),
+        sockets: new Set<DirectLineMock.Socket>(),
         conversation: [],
         token: 'tokenA',
     };
@@ -334,8 +93,8 @@ test('TestWithMocks', () => {
 
     const options: DirectLineExport.Services = {
         scheduler,
-        WebSocket: mockWebSocket(server),
-        ajax: mockAjax(server),
+        WebSocket: DirectLineMock.mockWebSocket(server),
+        ajax: DirectLineMock.mockAjax(server),
         random: () => 0,
     };
 

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -77,12 +77,7 @@ describe("MockSuite", () => {
 
         scheduler.maxFrames = 60 * 1000;
 
-        const server: DirectLineMock.Server = {
-            scheduler,
-            sockets: new Set<DirectLineMock.Socket>(),
-            conversation: [],
-            token: 'tokenA',
-        };
+        const server = DirectLineMock.mockServer(scheduler);
 
         const expected = {
             x: DirectLineMock.mockActivity('x'),

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -125,6 +125,31 @@ describe("MockSuite", () => {
         z: DirectLineMock.mockActivity('z'),
     };
 
+    test('HappyPath', () => {
+        // arrange
+
+        const scenario = function* (): IterableIterator<Observable<unknown>> {
+            yield Observable.timer(200, scheduler);
+            yield directline.postActivity(expected.x);
+            yield Observable.timer(200, scheduler);
+            yield directline.postActivity(expected.y);
+            yield Observable.timer(200, scheduler);
+        };
+
+        subscriptions.push(lazyConcat(scenario()).observeOn(scheduler).subscribe());
+
+        const actual: Array<DirectLineExport.Activity> = [];
+        subscriptions.push(directline.activity$.subscribe(a => actual.push(a)));
+
+        // act
+
+        scheduler.flush();
+
+        // assert
+
+        expect(actual).toStrictEqual([expected.x, expected.y]);
+    });
+
     test('ReconnectOnClose', () => {
         // arrange
 
@@ -140,9 +165,7 @@ describe("MockSuite", () => {
         subscriptions.push(lazyConcat(scenario()).observeOn(scheduler).subscribe());
 
         const actual: Array<DirectLineExport.Activity> = [];
-        subscriptions.push(directline.activity$.subscribe(a => {
-            actual.push(a);
-        }));
+        subscriptions.push(directline.activity$.subscribe(a => actual.push(a)));
 
         // act
 

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -119,13 +119,14 @@ describe("MockSuite", () => {
         }
     })
 
+    const expected = {
+        x: DirectLineMock.mockActivity('x'),
+        y: DirectLineMock.mockActivity('y'),
+        z: DirectLineMock.mockActivity('z'),
+    };
+
     test('ReconnectOnClose', () => {
         // arrange
-
-        const expected = {
-            x: DirectLineMock.mockActivity('x'),
-            y: DirectLineMock.mockActivity('y'),
-        };
 
         const scenario = function* (): IterableIterator<Observable<unknown>> {
             yield Observable.timer(200, scheduler);

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -1,4 +1,8 @@
 import * as DirectLineExport from "./directLine";
+import { TestScheduler, Observable, BehaviorSubject, ReplaySubject, AsyncSubject, Subscription, Subscriber } from "rxjs";
+import { AjaxCreationMethod, AjaxRequest, AjaxResponse } from "rxjs/observable/dom/AjaxObservable";
+import { IScheduler } from "rxjs/Scheduler";
+import { Action } from "rxjs/scheduler/Action";
 
 declare var process: {
     arch: string;
@@ -17,7 +21,7 @@ test("#setConnectionStatusFallback", () => {
     const testFallback = setConnectionStatusFallback(0, 1);
     let idx = 4;
     while (idx--) {
-      expect(testFallback(0)).toBe(0);
+        expect(testFallback(0)).toBe(0);
     }
     // fallback will be triggered
     expect(testFallback(0)).toBe(1);
@@ -60,4 +64,241 @@ describe("#commonHeaders", () => {
             "x-ms-bot-agent": botAgent
         });
     })
+});
+
+interface MockServer {
+    scheduler: TestScheduler;
+    sockets: Set<WebSocket>;
+    conversation: Array<DirectLineExport.Activity>;
+}
+
+const notImplemented = () => { throw new Error('not implemented') };
+
+const mockAjax = (server: MockServer): AjaxCreationMethod => {
+
+    const jax = (urlOrRequest: string | AjaxRequest): AjaxResponse => {
+        if (typeof urlOrRequest !== 'string') {
+            const { url } = urlOrRequest;
+            console.log(url);
+            const parts = url.split(/[\/\?]/);
+            if (parts[5] === 'conversations') {
+                if (parts[7] === 'activities') {
+                    const activity: DirectLineExport.Activity = urlOrRequest.body;
+
+                    const watermark = server.conversation.push(activity).toString();
+
+                    const activityGroup: DirectLineExport.ActivityGroup = {
+                        activities: [
+                            activity
+                        ],
+                        watermark,
+                    }
+                    const message = new MessageEvent('type', { data: JSON.stringify(activityGroup) });
+
+                    for (const socket of server.sockets) {
+                        schedule(
+                            server.scheduler,
+                            () => socket.onmessage(message));
+                    }
+
+                    const response: Partial<AjaxResponse> = {
+                        response: { id: 'messageId' },
+                    }
+
+                    return response as AjaxResponse;
+                }
+                else {
+                    const conversation: DirectLineExport.Conversation = {
+                        conversationId: 'conversationId',
+                        token: 'token',
+                        streamUrl: 'streamUrl',
+                    };
+
+                    const response: Partial<AjaxResponse> = {
+                        response: conversation,
+                    }
+
+                    return response as AjaxResponse;
+                }
+            }
+        }
+
+        throw new Error();
+    };
+
+    const method = (urlOrRequest: string | AjaxRequest): Observable<AjaxResponse> =>
+        new Observable<AjaxResponse>(subscriber => {
+            schedule(
+                server.scheduler,
+                () => {
+                    try {
+                        subscriber.next(jax(urlOrRequest));
+                        subscriber.complete();
+                    }
+                    catch (error) {
+                        subscriber.error(error);
+                    }
+                });
+        });
+
+    type ValueType<T, V> = {
+        [K in keyof T]: T[K] extends V ? T[K] : never;
+    }
+
+    type Properties = ValueType<AjaxCreationMethod, Function>;
+
+    const properties: Properties = {
+        get: (url: string, headers?: Object): Observable<AjaxResponse> => notImplemented(),
+        post: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
+        put: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
+        patch: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
+        delete: (url: string, headers?: Object): Observable<AjaxResponse> => notImplemented(),
+        getJSON: (url: string, headers?: Object) => notImplemented(),
+    };
+
+    return Object.assign(method, properties);
+}
+
+type WebSocketConstructor = typeof WebSocket;
+type EventHandler<E extends Event> = (this: WebSocket, ev: E) => any;
+
+type Work<T> = (this: Action<T>, state?: T) => void;
+const schedule = (scheduler: IScheduler, ...works: Array<Work<undefined>>) => {
+    for (const work of works) {
+        scheduler.schedule(work);
+    }
+}
+
+const mockWebSocket = (server: MockServer): WebSocketConstructor =>
+    class MockWebSocket implements WebSocket {
+        constructor(url: string, protocols?: string | string[]) {
+            this.server = server;
+            schedule(
+                this.server.scheduler,
+                () => this.readyState = WebSocket.CONNECTING,
+                () => {
+                    this.server.sockets.add(this);
+                    this.onopen(new Event('open'));
+                },
+                () => this.readyState = WebSocket.OPEN);
+        }
+
+        private readonly server: MockServer;
+
+        binaryType: BinaryType = 'arraybuffer';
+        readonly bufferedAmount: number = 0;
+        readonly extensions: string = '';
+        readonly protocol: string = 'https';
+        readyState: number = WebSocket.CLOSED;
+        readonly url: string = '';
+        readonly CLOSED: number = WebSocket.CLOSED;
+        readonly CLOSING: number = WebSocket.CLOSING;
+        readonly CONNECTING: number = WebSocket.CONNECTING;
+        readonly OPEN: number = WebSocket.OPEN;
+
+        onclose: EventHandler<CloseEvent>;
+        onerror: EventHandler<Event>;
+        onmessage: EventHandler<MessageEvent>;
+        onopen: EventHandler<Event>;
+
+        close(code?: number, reason?: string): void {
+            schedule(
+                this.server.scheduler,
+                () => this.readyState = WebSocket.CLOSING,
+                () => {
+                    this.onclose(new CloseEvent('close'))
+                    this.server.sockets.delete(this);
+                },
+                () => this.readyState = WebSocket.CLOSED);
+        }
+
+        send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
+        }
+
+        addEventListener() { throw new Error(); }
+        removeEventListener() { throw new Error(); }
+        dispatchEvent(): boolean { throw new Error(); }
+
+        static CLOSED = WebSocket.CLOSED;
+        static CLOSING = WebSocket.CLOSING;
+        static CONNECTING = WebSocket.CONNECTING;
+        static OPEN = WebSocket.OPEN;
+    };
+
+test('TestWithMocks', () => {
+
+    const { DirectLine } = DirectLineExport;
+
+    // setup
+
+    const scheduler = new TestScheduler((actual, expected) =>
+        expect(expected).toBe(actual));
+
+    const server: MockServer = {
+        scheduler,
+        sockets: new Set<WebSocket>(),
+        conversation: [],
+    };
+
+    const makeActivity = (text: string): DirectLineExport.Activity => ({ type: 'message', from: { id: 'sender' }, text });
+
+    const expected = {
+        x: makeActivity('x'),
+        y: makeActivity('y'),
+    };
+
+    // arrange
+
+    const options: DirectLineExport.Services = {
+        scheduler,
+        WebSocket: mockWebSocket(server),
+        ajax: mockAjax(server),
+    };
+
+    const directline = new DirectLine(options);
+
+    const subscriptions: Array<Subscription> = [];
+
+    try {
+
+        // const activity$ = scheduler.createColdObservable<DirectLineExport.Activity>('--x--y--|', expected);
+        // subscriptions.push(activity$.flatMap(a =>
+        //     directline.postActivity(a)).observeOn(scheduler).subscribe());
+
+        const scenario = [
+            Observable.empty().delay(200, scheduler),
+            directline.postActivity(expected.x),
+            // Observable.of(3).do(() => {
+            //     server.sockets.forEach(s => s.onerror(new Event('error')))
+            //     server.sockets.forEach(s => s.onclose(new CloseEvent('close')))
+            // }),
+            Observable.empty().delay(200, scheduler),
+            directline.postActivity(expected.y),
+            Observable.empty().delay(200, scheduler),
+        ];
+
+        subscriptions.push(Observable.concat(...scenario, scheduler).observeOn(scheduler).subscribe());
+
+        const actual: Array<DirectLineExport.Activity> = [];
+        subscriptions.push(directline.activity$.subscribe(a => {
+            actual.push(a);
+        }));
+
+        // scheduler.expectObservable(directline.activity$).toBe('--x--y--|', activities);
+
+        // act
+
+        scheduler.flush();
+
+        // assert
+
+        expect(actual).toStrictEqual([expected.x, expected.y]);
+    }
+    finally {
+        // cleanup
+
+        for (const subscription of subscriptions) {
+            subscription.unsubscribe();
+        }
+    }
 });

--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -2,7 +2,7 @@ import * as DirectLineExport from "./directLine";
 import * as DirectLineMock from './directLine.mock';
 import { TestScheduler, Observable, Subscription, AjaxResponse } from "rxjs";
 // @ts-ignore
-import {version} from "../package.json";
+import { version } from "../package.json";
 
 declare var process: {
     arch: string;
@@ -66,7 +66,7 @@ describe("#commonHeaders", () => {
     })
 });
 
-describe("MockSuite", () => {
+describe('MockSuite', () => {
 
     const lazyConcat = <T>(items: Iterable<Observable<T>>): Observable<T> =>
         new Observable<T>(subscriber => {
@@ -83,7 +83,8 @@ describe("MockSuite", () => {
                         inner = result.value.subscribe(
                             value => subscriber.next(value),
                             error => subscriber.error(error),
-                            pump);
+                            pump
+                        );
                     }
                 }
                 catch (error) {

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs/Observable';
 import { IScheduler } from 'rxjs/Scheduler';
 import { Subscriber } from 'rxjs/Subscriber';
 import { Subscription } from 'rxjs/Subscription';
-import { async } from 'rxjs/Scheduler/async';
+import { async as AsyncScheduler } from 'rxjs/scheduler/async';
 
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/combineLatest';
@@ -405,10 +405,10 @@ const wrapWithRetry = (source: AjaxCreationMethod, scheduler: IScheduler): AjaxC
 }
 
 const makeServices = (services: Partial<Services>): Services => {
-    const serviceScheduler = services.scheduler || async;
+    const scheduler = services.scheduler || AsyncScheduler;
     return {
-    scheduler: serviceScheduler,
-    ajax: wrapWithRetry(services.ajax || Observable.ajax, serviceScheduler),
+    scheduler,
+    ajax: wrapWithRetry(services.ajax || Observable.ajax, scheduler),
     WebSocket: services.WebSocket || WebSocket,
     random: services.random || Math.random,
 }};

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -376,7 +376,7 @@ export interface Services {
 
 const wrapWithRetry = (source: AjaxCreationMethod, scheduler: IScheduler): AjaxCreationMethod =>{
 
-    const notImplemented = (): never => { throw new Error('not implemented') };
+    const notImplemented = (): never => { throw new Error('not implemented'); };
 
     const inner = (response$ : Observable<AjaxResponse>) => {
         return response$
@@ -385,7 +385,7 @@ const wrapWithRetry = (source: AjaxCreationMethod, scheduler: IScheduler): AjaxC
                 const retryAfterValue = err.xhr.getResponseHeader('Retry-After');
                 const retryAfter = Number(retryAfterValue);
                 if(!isNaN(retryAfter)){
-                    return Observable.timer(Number(retryAfter), scheduler)
+                    return Observable.timer(retryAfter, scheduler)
                     .flatMap(_ => Observable.throw(err, scheduler));
                 }
             }
@@ -398,7 +398,7 @@ const wrapWithRetry = (source: AjaxCreationMethod, scheduler: IScheduler): AjaxC
         return inner(source(urlOrRequest));
     };
 
-    return  Object.assign(outer, {
+    return Object.assign(outer, {
         get: (url: string, headers?: Object): Observable<AjaxResponse> => notImplemented(),
         post: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
         put: (url: string, body?: any, headers?: Object): Observable<AjaxResponse> => notImplemented(),
@@ -617,7 +617,7 @@ export class DirectLine implements IBotConnection {
         .map(ajaxResponse => {
             try{
                 if(!this.botIdHeader ){
-                    this.botIdHeader = ajaxResponse.xhr.getResponseHeader('x-ms-botid');
+                    this.botIdHeader = ajaxResponse.xhr.getResponseHeader('x-ms-bot-id');
                 }
             }
             catch{/*don't care if the above throws for any reason*/}
@@ -982,7 +982,7 @@ export class DirectLine implements IBotConnection {
             return Object.assign({
                 "Authorization": `Bearer ${this.token}`,
                 "x-ms-bot-agent": this._botAgent
-            },  this.botIdHeader ? {'x-ms-botid': this.botIdHeader}: null);
+            },  this.botIdHeader ? {'x-ms-bot-id': this.botIdHeader}: null);
     }
 
     private getBotAgent(customAgent: string = ''): string {

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -385,9 +385,11 @@ const wrapWithRetry = (source: AjaxCreationMethod, scheduler: IScheduler): AjaxC
             if(err.status === 429){
                 const retryAfter = err.xhr.getResponseHeader('Retry-After');
                 if(retryAfter && !isNaN(Number(retryAfter))){
-                    return Observable.throw(err).delay(Number(retryAfter), scheduler);
+                    return Observable.throw(err, scheduler).delay(Number(retryAfter), scheduler);
                 }
             }
+
+            return Observable.throw(err, scheduler);
         });
         // .concatMap((response: AjaxResponse) => {
         //     if(response.status === 429){
@@ -624,7 +626,7 @@ export class DirectLine implements IBotConnection {
         .retryWhen(error$ =>
             // for now we deem 4xx and 5xx errors as unrecoverable
             // for everything else (timeouts), retry for a while
-            error$.mergeMap((error) {
+            error$.mergeMap((error) => {
                 return error.status >= 400 && error.status < 600
                 ? Observable.throw(error, this.services.scheduler)
                 : Observable.of(error, this.services.scheduler)

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -384,6 +384,7 @@ const wrapWithRetry = (source: AjaxCreationMethod, scheduler: IScheduler): AjaxC
             if(err.status === 429){
                 const retryAfter = err.xhr.getResponseHeader('Retry-After');
                 if(retryAfter && !isNaN(Number(retryAfter))){
+                    console.log('delaying by ' + retryAfter);
                     return Observable.throw(err, scheduler).delay(Number(retryAfter), scheduler);
                 }
             }
@@ -611,7 +612,7 @@ export class DirectLine implements IBotConnection {
             ? `${this.domain}/conversations/${this.conversationId}?watermark=${this.watermark}`
             : `${this.domain}/conversations`;
         const method = this.conversationId ? "GET" : "POST";
-
+        console.log('start conversation called');
         return this.services.ajax({
             method,
             url,
@@ -632,6 +633,7 @@ export class DirectLine implements IBotConnection {
             // for now we deem 4xx and 5xx errors as unrecoverable
             // for everything else (timeouts), retry for a while
             error$.mergeMap((error) => {
+                console.log(error.status);
                 return error.status >= 400 && error.status < 600
                 ? Observable.throw(error, this.services.scheduler)
                 : Observable.of(error, this.services.scheduler)

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -368,12 +368,14 @@ export interface Services {
     scheduler: IScheduler;
     WebSocket: typeof WebSocket;
     ajax: AjaxCreationMethod;
+    random: () => number;
 }
 
 const makeServices = (services: Partial<Services>): Services => ({
     scheduler: services.scheduler || async,
     ajax: services.ajax || Observable.ajax,
     WebSocket: services.WebSocket || WebSocket,
+    random: services.random || Math.random,
 });
 
 const lifetimeRefreshToken = 30 * 60 * 1000;
@@ -847,7 +849,7 @@ export class DirectLine implements IBotConnection {
 
     // Returns the delay duration in milliseconds
     private getRetryDelay() {
-        return Math.floor(3000 + Math.random() * 12000);
+        return Math.floor(3000 + this.services.random() * 12000);
     }
 
     // Originally we used Observable.webSocket, but it's fairly opinionated and I ended up writing

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs/Observable';
 import { IScheduler } from 'rxjs/Scheduler';
 import { Subscriber } from 'rxjs/Subscriber';
 import { Subscription } from 'rxjs/Subscription';
+import { async } from 'rxjs/Scheduler/async';
 
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/combineLatest';
@@ -370,7 +371,7 @@ export interface Services {
 }
 
 const makeServices = (services: Partial<Services>): Services => ({
-    scheduler: services.scheduler,
+    scheduler: services.scheduler || async,
     ajax: services.ajax || Observable.ajax,
     WebSocket: services.WebSocket || WebSocket,
 });

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -374,7 +374,7 @@ export interface Services {
     random: () => number;
 }
 
-const wrapWithRetry = (source: AjaxCreationMethod, scheduler: IScheduler): AjaxCreationMethod =>{
+const wrapAjaxWithRetry = (source: AjaxCreationMethod, scheduler: IScheduler): AjaxCreationMethod =>{
 
     const notImplemented = (): never => { throw new Error('not implemented'); };
 
@@ -411,11 +411,12 @@ const wrapWithRetry = (source: AjaxCreationMethod, scheduler: IScheduler): AjaxC
 const makeServices = (services: Partial<Services>): Services => {
     const scheduler = services.scheduler || AsyncScheduler;
     return {
-    scheduler,
-    ajax: wrapWithRetry(services.ajax || Observable.ajax, scheduler),
-    WebSocket: services.WebSocket || WebSocket,
-    random: services.random || Math.random,
-}};
+        scheduler,
+        ajax: wrapAjaxWithRetry(services.ajax || Observable.ajax, scheduler),
+        WebSocket: services.WebSocket || WebSocket,
+        random: services.random || Math.random,
+    }
+}
 
 const lifetimeRefreshToken = 30 * 60 * 1000;
 const intervalRefreshToken = lifetimeRefreshToken / 2;

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -35,6 +35,7 @@ declare var process: {
     arch: string;
     env: {
         VERSION: string;
+        npm_package_version: string;
     };
     platform: string;
     release: string;
@@ -944,6 +945,6 @@ export class DirectLine implements IBotConnection {
             clientAgent += `; ${customAgent}`
         }
 
-        return `${DIRECT_LINE_VERSION} (${clientAgent})`;
+        return `${DIRECT_LINE_VERSION} (${clientAgent} ${process.env.npm_package_version})`;
     }
 }

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -1,8 +1,9 @@
 // In order to keep file size down, only import the parts of rxjs that we use
 
-import { AjaxResponse, AjaxRequest } from 'rxjs/observable/dom/AjaxObservable';
+import { AjaxResponse, AjaxCreationMethod } from 'rxjs/observable/dom/AjaxObservable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
+import { IScheduler } from 'rxjs/Scheduler';
 import { Subscriber } from 'rxjs/Subscriber';
 import { Subscription } from 'rxjs/Subscription';
 
@@ -333,7 +334,7 @@ export interface EventActivity extends IActivity {
 
 export type Activity = Message | Typing | EventActivity;
 
-interface ActivityGroup {
+export interface ActivityGroup {
     activities: Activity[],
     watermark: string
 }
@@ -361,6 +362,18 @@ export interface DirectLineOptions {
     // Attached to all requests to identify requesting agent.
     botAgent?: string
 }
+
+export interface Services {
+    scheduler: IScheduler;
+    WebSocket: typeof WebSocket;
+    ajax: AjaxCreationMethod;
+}
+
+const makeServices = (services: Partial<Services>): Services => ({
+    scheduler: services.scheduler,
+    ajax: services.ajax || Observable.ajax,
+    WebSocket: services.WebSocket || WebSocket,
+});
 
 const lifetimeRefreshToken = 30 * 60 * 1000;
 const intervalRefreshToken = lifetimeRefreshToken / 2;
@@ -403,6 +416,7 @@ export class DirectLine implements IBotConnection {
     private watermark = '';
     private streamUrl: string;
     private _botAgent = '';
+    private services: Services;
     private _userAgent: string;
     public referenceGrammarId: string;
 
@@ -410,7 +424,7 @@ export class DirectLine implements IBotConnection {
 
     private tokenRefreshSubscription: Subscription;
 
-    constructor(options: DirectLineOptions) {
+    constructor(options: DirectLineOptions & Partial<Services>) {
         this.secret = options.secret;
         this.token = options.secret || options.token;
         this.webSocket = (options.webSocket === undefined ? true : options.webSocket) && typeof WebSocket !== 'undefined' && WebSocket !== undefined;
@@ -436,6 +450,8 @@ export class DirectLine implements IBotConnection {
         }
 
         this._botAgent = this.getBotAgent(options.botAgent);
+
+        this.services = makeServices(options);
 
         const parsedPollingInterval = ~~options.pollingInterval;
 
@@ -470,7 +486,7 @@ export class DirectLine implements IBotConnection {
                 //if token and streamUrl are defined it means reconnect has already been done. Skipping it.
                 if (this.token && this.streamUrl) {
                     this.connectionStatus$.next(ConnectionStatus.Online);
-                    return Observable.of(connectionStatus);
+                    return Observable.of(connectionStatus, this.services.scheduler);
                 } else {
                     return this.startConversation().do(conversation => {
                         this.conversationId = conversation.conversationId;
@@ -488,23 +504,23 @@ export class DirectLine implements IBotConnection {
                 }
             }
             else {
-                return Observable.of(connectionStatus);
+                return Observable.of(connectionStatus, this.services.scheduler);
             }
         })
         .filter(connectionStatus => connectionStatus != ConnectionStatus.Uninitialized && connectionStatus != ConnectionStatus.Connecting)
         .flatMap(connectionStatus => {
             switch (connectionStatus) {
                 case ConnectionStatus.Ended:
-                    return Observable.throw(errorConversationEnded);
+                    return Observable.throw(errorConversationEnded, this.services.scheduler);
 
                 case ConnectionStatus.FailedToConnect:
-                    return Observable.throw(errorFailedToConnect);
+                    return Observable.throw(errorFailedToConnect, this.services.scheduler);
 
                 case ConnectionStatus.ExpiredToken:
-                    return Observable.of(connectionStatus);
+                    return Observable.of(connectionStatus, this.services.scheduler);
 
                 default:
-                    return Observable.of(connectionStatus);
+                    return Observable.of(connectionStatus, this.services.scheduler);
             }
         })
 
@@ -546,7 +562,7 @@ export class DirectLine implements IBotConnection {
             : `${this.domain}/conversations`;
         const method = this.conversationId ? "GET" : "POST";
 
-        return Observable.ajax({
+        return this.services.ajax({
             method,
             url,
             timeout,
@@ -561,16 +577,16 @@ export class DirectLine implements IBotConnection {
             // for now we deem 4xx and 5xx errors as unrecoverable
             // for everything else (timeouts), retry for a while
             error$.mergeMap(error => error.status >= 400 && error.status < 600
-                ? Observable.throw(error)
-                : Observable.of(error)
+                ? Observable.throw(error, this.services.scheduler)
+                : Observable.of(error, this.services.scheduler)
             )
-            .delay(timeout)
+            .delay(timeout, this.services.scheduler)
             .take(retries)
         )
     }
 
     private refreshTokenLoop() {
-        this.tokenRefreshSubscription = Observable.interval(intervalRefreshToken)
+        this.tokenRefreshSubscription = Observable.interval(intervalRefreshToken, this.services.scheduler)
         .flatMap(_ => this.refreshToken())
         .subscribe(token => {
             konsole.log("refreshing token", token, "at", new Date());
@@ -581,7 +597,7 @@ export class DirectLine implements IBotConnection {
     private refreshToken() {
         return this.checkConnection(true)
         .flatMap(_ =>
-            Observable.ajax({
+            this.services.ajax({
                 method: "POST",
                 url: `${this.domain}/tokens/refresh`,
                 timeout,
@@ -595,15 +611,15 @@ export class DirectLine implements IBotConnection {
                     if (error.status === 403) {
                         // if the token is expired there's no reason to keep trying
                         this.expiredToken();
-                        return Observable.throw(error);
+                        return Observable.throw(error, this.services.scheduler);
                     } else if (error.status === 404) {
                         // If the bot is gone, we should stop retrying
-                        return Observable.throw(error);
+                        return Observable.throw(error, this.services.scheduler);
                     }
 
-                    return Observable.of(error);
+                    return Observable.of(error, this.services.scheduler);
                 })
-                .delay(timeout)
+                .delay(timeout, this.services.scheduler)
                 .take(retries)
             )
         )
@@ -634,7 +650,7 @@ export class DirectLine implements IBotConnection {
         konsole.log("getSessionId");
         return this.checkConnection(true)
             .flatMap(_ =>
-                Observable.ajax({
+                this.services.ajax({
                     method: "GET",
                     url: `${this.domain}/session/getsessionid`,
                     withCredentials: true,
@@ -653,7 +669,7 @@ export class DirectLine implements IBotConnection {
                 })
                 .catch(error => {
                     konsole.log("getSessionId error: " + error.status);
-                    return Observable.of('');
+                    return Observable.of('', this.services.scheduler);
                 })
             )
             .catch(error => this.catchExpiredToken(error));
@@ -671,7 +687,7 @@ export class DirectLine implements IBotConnection {
         konsole.log("postActivity", activity);
         return this.checkConnection(true)
         .flatMap(_ =>
-            Observable.ajax({
+            this.services.ajax({
                 method: "POST",
                 url: `${this.domain}/conversations/${this.conversationId}/activities`,
                 body: activity,
@@ -711,9 +727,9 @@ export class DirectLine implements IBotConnection {
                 attachments: cleansedAttachments.map(({ contentUrl: string, ...others }) => ({ ...others }))
             })], { type: 'application/vnd.microsoft.activity' }));
 
-            return Observable.from(cleansedAttachments)
+            return Observable.from(cleansedAttachments, this.services.scheduler)
             .flatMap((media: Media) =>
-                Observable.ajax({
+                this.services.ajax({
                     method: "GET",
                     url: media.contentUrl,
                     responseType: 'arraybuffer'
@@ -725,7 +741,7 @@ export class DirectLine implements IBotConnection {
             .count()
         })
         .flatMap(_ =>
-            Observable.ajax({
+            this.services.ajax({
                 method: "POST",
                 url: `${this.domain}/conversations/${this.conversationId}/upload?userId=${message.from.id}`,
                 body: formData,
@@ -746,14 +762,14 @@ export class DirectLine implements IBotConnection {
             this.expiredToken();
         else if (error.status >= 400 && error.status < 500)
             // more unrecoverable errors
-            return Observable.throw(error);
-        return Observable.of("retry");
+            return Observable.throw(error, this.services.scheduler);
+        return Observable.of("retry", this.services.scheduler);
     }
 
     private catchExpiredToken(error: any) {
         return error === errorExpiredToken
-        ? Observable.of("retry")
-        : Observable.throw(error);
+        ? Observable.of("retry", this.services.scheduler)
+        : Observable.throw(error, this.services.scheduler);
     }
 
     private pollingGetActivity$() {
@@ -762,11 +778,13 @@ export class DirectLine implements IBotConnection {
             // the first event is produced immediately.
             const trigger$ = new BehaviorSubject<any>({});
 
+            // TODO: remove Date.now, use reactive interval to space out every request
+
             trigger$.subscribe(() => {
                 if (this.connectionStatus$.getValue() === ConnectionStatus.Online) {
                     const startTimestamp = Date.now();
 
-                    Observable.ajax({
+                    this.services.ajax({
                         headers: {
                             Accept: 'application/json',
                             ...this.commonHeaders()
@@ -811,7 +829,7 @@ export class DirectLine implements IBotConnection {
     private observableFromActivityGroup(activityGroup: ActivityGroup) {
         if (activityGroup.watermark)
             this.watermark = activityGroup.watermark;
-        return Observable.from(activityGroup.activities);
+        return Observable.from(activityGroup.activities, this.services.scheduler);
     }
 
     private webSocketActivity$(): Observable<Activity> {
@@ -821,7 +839,7 @@ export class DirectLine implements IBotConnection {
             // WebSockets can be closed by the server or the browser. In the former case we need to
             // retrieve a new streamUrl. In the latter case we could first retry with the current streamUrl,
             // but it's simpler just to always fetch a new one.
-            .retryWhen(error$ => error$.delay(this.getRetryDelay()).mergeMap(error => this.reconnectToConversation()))
+            .retryWhen(error$ => error$.delay(this.getRetryDelay(), this.services.scheduler).mergeMap(error => this.reconnectToConversation()))
         )
         .flatMap(activityGroup => this.observableFromActivityGroup(activityGroup))
     }
@@ -831,13 +849,13 @@ export class DirectLine implements IBotConnection {
         return Math.floor(3000 + Math.random() * 12000);
     }
 
-    // Originally we used Observable.webSocket, but it's fairly opionated  and I ended up writing
+    // Originally we used Observable.webSocket, but it's fairly opinionated and I ended up writing
     // a lot of code to work around their implemention details. Since WebChat is meant to be a reference
     // implementation, I decided roll the below, where the logic is more purposeful. - @billba
     private observableWebSocket<T>() {
         return Observable.create((subscriber: Subscriber<T>) => {
             konsole.log("creating WebSocket", this.streamUrl);
-            const ws = new WebSocket(this.streamUrl);
+            const ws = new this.services.WebSocket(this.streamUrl);
             let sub: Subscription;
 
             ws.onopen = open => {
@@ -846,7 +864,7 @@ export class DirectLine implements IBotConnection {
                 // If we periodically ping the server with empty messages, it helps Chrome
                 // realize when connection breaks, and close the socket. We then throw an
                 // error, and that give us the opportunity to attempt to reconnect.
-                sub = Observable.interval(timeout).subscribe(_ => {
+                sub = Observable.interval(timeout, this.services.scheduler).subscribe(_ => {
                     try {
                         ws.send("")
                     } catch(e) {
@@ -876,7 +894,7 @@ export class DirectLine implements IBotConnection {
     private reconnectToConversation() {
         return this.checkConnection(true)
         .flatMap(_ =>
-            Observable.ajax({
+            this.services.ajax({
                 method: "GET",
                 url: `${this.domain}/conversations/${this.conversationId}?watermark=${this.watermark}`,
                 timeout,
@@ -898,12 +916,12 @@ export class DirectLine implements IBotConnection {
                         // website might eventually call reconnect() with a new token and streamUrl.
                         this.expiredToken();
                     } else if (error.status === 404) {
-                        return Observable.throw(errorConversationEnded);
+                        return Observable.throw(errorConversationEnded, this.services.scheduler);
                     }
 
-                    return Observable.of(error);
+                    return Observable.of(error, this.services.scheduler);
                 })
-                .delay(timeout)
+                .delay(timeout, this.services.scheduler)
                 .take(retries)
             )
         )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "declaration": true,
     "declarationDir": "lib",
     "emitDeclarationOnly": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "resolveJsonModule": true
   },
   "exclude": [
     "__tests__/**/*.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,7 @@
     "declaration": true,
     "declarationDir": "lib",
     "emitDeclarationOnly": true,
-    "sourceMap": true,
-    "resolveJsonModule": true
+    "sourceMap": true
   },
   "exclude": [
     "__tests__/**/*.js",


### PR DESCRIPTION
- Added support for retry-after header and version information for directline-js to the useragent.
- Interfaced out dependencies with side effects (like Ajax) to make the main code more unit testable and also to be able to inject global functionality 
- Added some unit testing infrastructure using the rxjs test scheduler 
- Added tests for the new functionality added