### PR TITLE
Lockdown dependencies and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Lock down on version of dependencies, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/XXX)
+- Lock down on version of dependencies, by [@compulim](https://github.com/compulim), in PR [#280](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/280)
    - [`rxjs@5.5.10`](https://npmjs.com/package/rxjs)
       - This version is selected out of the previous commit of `package-lock.json`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added support of Direct Line App Service Extension, by [@ckkashyap](https://github.com/ckkashyap), in PR [#183](https://github.com/microsoft/BotFramework-DirectLineJS/pull/183) and [#274](https://github.com/microsoft/BotFramework-DirectLineJS/pull/274)
+- Added support for `Retry-After` header and version information to `x-ms-bot-agent` header, by [@swagatmishra2007](https://github.com/swagatmishra2007), in PR [#247](https://github.com/microsoft/BotFramework-DirectLineJS/pull/247)
+   - Also improved testability of the package
+
+### Changed
+
+- Lock down on version of dependencies, by [@compulim](https://github.com/compulim), in PR [#XXX](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/XXX)
+   - [`rxjs@5.5.10`](https://npmjs.com/package/rxjs)
+      - This version is selected out of the previous commit of `package-lock.json`
+
+## [0.11.6] - 2019-10-25
+
 ### Fixed
 
 - Reverting PR [#171](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/171) and PR [#172](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/172), which caused infinite loop of reconnections, by [@compulim](https://github.com/compulim) in PR [#240](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/240)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8437,9 +8437,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regenerator-transform": {
       "version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
   "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.6.0",
+    "@babel/runtime": "7.6.0",
     "botframework-streaming": "4.8.0",
-    "core-js": "^3.6.4",
-    "cross-fetch": "^3.0.4",
-    "rxjs": "^5.0.3",
-    "url-search-params-polyfill": "^8.0.0"
+    "core-js": "3.6.4",
+    "cross-fetch": "3.0.4",
+    "rxjs": "5.5.10",
+    "url-search-params-polyfill": "8.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.0",


### PR DESCRIPTION
Locking down all production dependencies and prepare for deployment.

I selected `rxjs@5.5.10` because it was found in `package-lock.json`. This introduce minimum lines to modify in `package-lock.json`.

## Changelog

### Changed

- Lock down on version of dependencies, by [@compulim](https://github.com/compulim), in PR [#280](https://github.com/Microsoft/BotFramework-DirectLineJS/pull/280)
   - [`rxjs@5.5.10`](https://npmjs.com/package/rxjs)
      - This version is selected out of the previous commit of `package-lock.json`
