### PR TITLE
Remove botid header from directlinejs

### DIFF
--- a/src/directLine.test.ts
+++ b/src/directLine.test.ts
@@ -241,48 +241,4 @@ describe('MockSuite', () => {
         expect(actualError.status).toStrictEqual(429);
         expect(endTime - startTime).toStrictEqual(10);
     });
-
-    test('SendDebugHeader', () => {
-        let expectedBotId:string;
-        const actual = 'botid';
-        services.ajax = DirectLineMock.mockAjax(server, (urlOrRequest) => {
-            if(typeof urlOrRequest === 'string'){
-                throw new Error();
-            }
-
-            if(urlOrRequest.url && urlOrRequest.url.indexOf(server.conversation.conversationId)>0){
-                 const response: Partial<AjaxResponse> = {
-                    response: {id:'blah'},
-                    status: 200
-                };
-                expectedBotId = urlOrRequest.headers['x-ms-bot-id'];
-                return response as AjaxResponse;
-            }
-            else if(urlOrRequest.url && urlOrRequest.url.indexOf('/conversations') > 0){
-                // start conversation
-                const response: Partial<AjaxResponse> = {
-                    response: server.conversation,
-                    status: 201,
-                    xhr: {
-                        getResponseHeader: (name) => actual
-                    } as XMLHttpRequest
-                };
-                return response as AjaxResponse;
-            }
-            throw new Error();
-        });
-        directline = new DirectLineExport.DirectLine(services);
-        const scenario = function* (): IterableIterator<Observable<unknown>> {
-            yield Observable.timer(200, scheduler);
-            yield directline.postActivity(expected.x).catch(() => Observable.empty(scheduler));
-        };
-
-        // lack of subscribe arguments means that the empty subscriber is used
-        // the empty subscriber will propagate observable errors on the JS call stack
-        // within the scheduler notification action handling loop because of the observeOn
-        subscriptions.push(lazyConcat(scenario()).observeOn(scheduler).subscribe());
-        scheduler.flush();
-
-        expect(expectedBotId).toBe(actual);
-    });
 });

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -466,7 +466,6 @@ export class DirectLine implements IBotConnection {
     private services: Services;
     private _userAgent: string;
     public referenceGrammarId: string;
-    private botIdHeader: string;
     private timeout = 20 * 1000;
     private retries: number;
 
@@ -627,15 +626,7 @@ export class DirectLine implements IBotConnection {
             }
         })
 //      .do(ajaxResponse => konsole.log("conversation ajaxResponse", ajaxResponse.response))
-        .map(ajaxResponse => {
-            try{
-                if(!this.botIdHeader ){
-                    this.botIdHeader = ajaxResponse.xhr.getResponseHeader('x-ms-bot-id');
-                }
-            }
-            catch{/*don't care if the above throws for any reason*/}
-            return ajaxResponse.response as Conversation;
-        })
+        .map(ajaxResponse => ajaxResponse.response as Conversation)
         .retryWhen(error$ =>
             // for now we deem 4xx and 5xx errors as unrecoverable
             // for everything else (timeouts), retry for a while
@@ -992,10 +983,10 @@ export class DirectLine implements IBotConnection {
     }
 
     private commonHeaders() {
-            return Object.assign({
-                "Authorization": `Bearer ${this.token}`,
-                "x-ms-bot-agent": this._botAgent
-            },  this.botIdHeader ? {'x-ms-bot-id': this.botIdHeader}: null);
+        return {
+            "Authorization": `Bearer ${this.token}`,
+            "x-ms-bot-agent": this._botAgent
+        };
     }
 
     private getBotAgent(customAgent: string = ''): string {


### PR DESCRIPTION
The service does not send this header (This was part of some planned work that was not done). 
The client code throws a "unable to get header" in console.log on chromium based browsers, which has lead to customer concerns.
Since the header is unused, i am removing it