### PR TITLE
bump botframework-streaming@4.10.2-rc0

### DIFF
--- a/__tests__/setup/createDirectLine.js
+++ b/__tests__/setup/createDirectLine.js
@@ -1,8 +1,7 @@
 import fetch from 'node-fetch';
 
-import { DirectLine } from '../../src/directLine';
 import { userId as DEFAULT_USER_ID } from '../constants.json';
-import { DirectLineStreaming } from '../../src/directLineStreaming';
+import { DirectLine, DirectLineStreaming } from '../../dist/directline';
 
 const {
   DIRECT_LINE_SECRET,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2953,19 +2953,24 @@
       "dev": true
     },
     "botframework-streaming": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.9.2.tgz",
-      "integrity": "sha512-Vl94e6SnKUp94R1akKpFAUK5kinaKLAAmSBrol/fV8xghtfsZNLMWyVLDYPmstWdemuH5Jccpahb3mgPuEqV8A==",
+      "version": "4.10.2-rc0",
+      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.10.2-rc0.tgz",
+      "integrity": "sha512-yqh4UTBv9qLWSDzRiDOlvxWtxtOyMjgVb6yJFcoBnTMNt8wzopSr/ztb5g9cQ0sV80DBVzXcRGb2iZ4fjGiCQg==",
       "requires": {
         "@types/ws": "^6.0.3",
-        "uuid": "^3.3.2",
+        "uuid": "^3.4.0",
         "ws": "^7.1.2"
       },
       "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        },
         "ws": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
         }
       }
     },
@@ -6327,7 +6332,8 @@
         },
         "yargs-parser": {
           "version": "13.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -9932,7 +9938,8 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "7.6.0",
-    "botframework-streaming": "4.9.2",
+    "botframework-streaming": "4.10.2-rc0",
     "core-js": "3.6.4",
     "cross-fetch": "3.0.4",
     "rxjs": "5.5.10",


### PR DESCRIPTION
The bump addresses the CSP issue around "unsafe-eval" referenced in https://github.com/microsoft/BotFramework-WebChat/issues/3393#issuecomment-671425877 and https://github.com/microsoft/botbuilder-js/issues/2647.

I modified the `__tests__/setup/createDirectLine.js` to import from the `dist/` as these `__tests__` are run in `jsdom`, not a Node.js environment. By referencing `../../src`, the tests were attempting to use the Node.js distribution of `botframework-streaming` which resulted in the streaming tests failing.