### PR TITLE
bump botframework-streaming to 4.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped [`botframework-streaming@4.10.3`](https://npmjs.com/package/botframework-streaming), by [@stevengum](https://github.com/stevengum), in PR [#308](https://github.com/microsoft/BotFramework-DirectLineJS/pull/308)
+
 ## [0.13.0] - 2020-08-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -2953,9 +2953,9 @@
       "dev": true
     },
     "botframework-streaming": {
-      "version": "4.10.2-rc0",
-      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.10.2-rc0.tgz",
-      "integrity": "sha512-yqh4UTBv9qLWSDzRiDOlvxWtxtOyMjgVb6yJFcoBnTMNt8wzopSr/ztb5g9cQ0sV80DBVzXcRGb2iZ4fjGiCQg==",
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.10.3.tgz",
+      "integrity": "sha512-9g6942ejQQ6S72OT5uzN5HaKBYQrsDTXQ0d3Z9+7Q1Rj7gpJJEI0JzsSkX+80k746TQJEk3V7PRnV+HXNOqduA==",
       "requires": {
         "@types/ws": "^6.0.3",
         "uuid": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "7.6.0",
-    "botframework-streaming": "4.10.2-rc0",
+    "botframework-streaming": "4.10.3",
     "core-js": "3.6.4",
     "cross-fetch": "3.0.4",
     "rxjs": "5.5.10",


### PR DESCRIPTION
Bump to `botframework-streaming` to [4.10.3](https://github.com/microsoft/botbuilder-js/releases/tag/v4.10.3) which is the stable release that contains the content Security Policy fix in [PR #306](https://github.com/microsoft/BotFramework-DirectLineJS/pull/306)