### PR TITLE
Fix tests by restoring nock after test

### DIFF
--- a/__tests__/unhappy.brokenWebSocket.js
+++ b/__tests__/unhappy.brokenWebSocket.js
@@ -85,6 +85,10 @@ describe('Unhappy path', () => {
       defineEventAttribute(window.WebSocket.prototype, 'error');
     });
 
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
     test('should reconnect only once for every error', async () => {
       const directLine = new DirectLine({
         token: '123',


### PR DESCRIPTION
When running in CI, Jest run in `--runInBand` mode and Nock persists across test suite. That means it would interfere with another tests.

Adding `nock.cleanAll()` after test to clean up.