### PR TITLE
add support for conversationStartProperties in DirectLineStreaming

### DIFF
--- a/__tests__/happy.replaceActivityFromId.js
+++ b/__tests__/happy.replaceActivityFromId.js
@@ -13,7 +13,7 @@ describe('Happy path', () => {
   beforeEach(() => unsubscribes = []);
   afterEach(() => unsubscribes.forEach(fn => onErrorResumeNext(fn)));
 
-  describe('should receive the welcome message from bot', () => {
+  describe('should replace from.id on messages to bot', () => {
     let directLine;
 
     describe('using REST', () => {

--- a/src/directLineStreaming.ts
+++ b/src/directLineStreaming.ts
@@ -27,7 +27,14 @@ interface DirectLineStreamingOptions {
   conversationId?: string,
   domain: string,
   // Attached to all requests to identify requesting agent.
-  botAgent?: string
+  botAgent?: string,
+  conversationStartProperties?: {
+    user?: {
+      id?: string,
+      name?: string
+    },
+    locale?: string
+  }
 }
 
 class StreamHandler implements BFSE.RequestHandler {
@@ -102,6 +109,9 @@ export class DirectLineStreaming implements IBotConnection {
   private token: string;
   private streamConnection: BFSE.WebSocketClient;
   private queueActivities: boolean;
+  private readonly userIdOnStartConversation: string;
+  private readonly localeOnStartConversation: string;
+  private readonly usernameOnStartConversation: string;
 
   private _botAgent = '';
 
@@ -114,6 +124,12 @@ export class DirectLineStreaming implements IBotConnection {
 
     if (options.conversationId) {
       this.conversationId = options.conversationId;
+    }
+
+    if (options.conversationStartProperties) {
+      this.localeOnStartConversation = options.conversationStartProperties.locale;
+      this.userIdOnStartConversation = options.conversationStartProperties.user && options.conversationStartProperties.user.id;
+      this.usernameOnStartConversation = options.conversationStartProperties.user && options.conversationStartProperties.user.name;
     }
 
     this._botAgent = this.getBotAgent(options.botAgent);
@@ -288,6 +304,17 @@ export class DirectLineStreaming implements IBotConnection {
         this.queueActivities = true;
         await this.streamConnection.connect();
         const request = BFSE.StreamingRequest.create('POST', '/v3/directline/conversations');
+        request.setBody(
+          JSON.stringify(
+            {
+            user: {
+              id: this.userIdOnStartConversation,
+              name: this.usernameOnStartConversation
+            },
+            locale: this.localeOnStartConversation
+            }
+          )
+        );
         const response = await this.streamConnection.send(request);
         if (response.statusCode !== 200) throw new Error("Connection response code " + response.statusCode);
         if (response.streams.length !== 1) throw new Error("Expected 1 stream but got " + response.streams.length);


### PR DESCRIPTION
# Do not merge - Pending Service-side changes

- [ ] Service-side changes complete
- [ ] Change `ConversationStartProperties` to **`ConversationStartParameters`**
- [ ] E2E test
  - [ ] Verify unit tests

### Description
Allow developers to provide a custom `user.id` and `user.name` to be used with Direct Line App Service Extension when starting new conversations.

### Example of new code path being invoked by Web Chat:
```js
          window.WebChat.renderWebChat(
              {
                  directLine: await window.WebChat.createDirectLineAppServiceExtension({
                      domain: '<WindowsAppServiceUrlForBot>/.bot/v3/directline',
                      token: response.token,
                      conversationStartProperties: {
                          user: {
                              id: userID,
                              name: username
                          },
                          locale: 'en-us' 
                      }
                  }),
                  store,
                  userID,
                  username
              },
              document.getElementById('webchat')
          );
```

### Specific Changes
- fixed test suite name for `happy.replaceActivityFromId.js`
- added `'should use conversationStartProperties when starting conversation'` test suite with Direct Line App Service Extensions test
  - test added to `happy.userIdOnStartConversation.js`