### PR TITLE
Adding a callback option to customize how tokens are refreshed for calls

### DIFF
--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -475,6 +475,7 @@ export class DirectLine implements IBotConnection {
 
     private localeOnStartConversation: string;
     private userIdOnStartConversation: string;
+    private siteId: string;
 
     private pollingInterval: number = 1000; //ms
 
@@ -486,11 +487,17 @@ export class DirectLine implements IBotConnection {
         this.refreshToken$ = options.refreshToken$;
         this.webSocket = (options.webSocket === undefined ? true : options.webSocket) && typeof WebSocket !== 'undefined' && WebSocket !== undefined;
 
-        if (options.conversationStartProperties && options.conversationStartProperties.locale) {
-            if (Object.prototype.toString.call(options.conversationStartProperties.locale) === '[object String]') {
-                this.localeOnStartConversation = options.conversationStartProperties.locale;
-            } else {
-                console.warn('DirectLineJS: conversationStartProperties.locale was ignored: the locale name may be a BCP 47 language tag');
+        if (options.conversationStartProperties) {
+            if (options.conversationStartProperties.locale) {
+                if (Object.prototype.toString.call(options.conversationStartProperties.locale) === '[object String]') {
+                    this.localeOnStartConversation = options.conversationStartProperties.locale;
+                } else {
+                    console.warn('DirectLineJS: conversationStartProperties.locale was ignored: the locale name may be a BCP 47 language tag');
+                }
+            }
+
+            if (options.conversationStartProperties.siteId) {
+                this.siteId = options.conversationStartProperties.siteId;
             }
         }
 
@@ -638,7 +645,8 @@ export class DirectLine implements IBotConnection {
                 user: {
                     id: this.userIdOnStartConversation
                 },
-                locale: this.localeOnStartConversation
+                locale: this.localeOnStartConversation,
+                siteId: this.siteId
               };
         return this.services.ajax({
             method,

--- a/src/directLine.ts
+++ b/src/directLine.ts
@@ -13,7 +13,6 @@ import jwtDecode, { JwtPayload, InvalidTokenError } from 'jwt-decode';
 
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/combineLatest';
-import 'rxjs/add/operator/concat';
 import 'rxjs/add/operator/count';
 import 'rxjs/add/operator/delay';
 import 'rxjs/add/operator/do';
@@ -560,19 +559,19 @@ export class DirectLine implements IBotConnection {
                     this.connectionStatus$.next(ConnectionStatus.Online);
                     return Observable.of(connectionStatus, this.services.scheduler);
                 } else {
-                        return this.startConversation().do(conversation => {
-                            this.conversationId = conversation.conversationId;
-                            this.token = this.secret || conversation.token;
-                            this.streamUrl = conversation.streamUrl;
-                            this.referenceGrammarId = conversation.referenceGrammarId;
-                            if (!this.secret)
-                                this.refreshTokenLoop();
+                    return this.startConversation().do(conversation => {
+                        this.conversationId = conversation.conversationId;
+                        this.token = this.secret || conversation.token;
+                        this.streamUrl = conversation.streamUrl;
+                        this.referenceGrammarId = conversation.referenceGrammarId;
+                        if (!this.secret)
+                            this.refreshTokenLoop();
 
-                            this.connectionStatus$.next(ConnectionStatus.Online);
-                        }, error => {
-                            this.connectionStatus$.next(ConnectionStatus.FailedToConnect);
-                        })
-                        .map(_ => connectionStatus);
+                        this.connectionStatus$.next(ConnectionStatus.Online);
+                    }, error => {
+                        this.connectionStatus$.next(ConnectionStatus.FailedToConnect);
+                    })
+                    .map(_ => connectionStatus);
                 }
             }
             else {


### PR DESCRIPTION
This change will enable users to customize how DLJS refreshes tokens, so as not to rely on the built-in mechanism. The mechanism is an observable, passed into the options.