### PR TITLE
Bump to botframework-streaming@4.20.0-dev.20230209.fbd66a2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#390](https://github.com/microsoft/BotFramework-DirectLineJS/pull/390)
+- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#390](https://github.com/microsoft/BotFramework-DirectLineJS/pull/390) and [#388](https://github.com/microsoft/BotFramework-DirectLineJS/pull/388)
+   - Production dependencies
+      - [`botframework-streaming@4.20.0-dev.20230209.fbd66a2`](https://npmjs.com/package/botframework-streaming)
    - Development dependencies
       - [`restify@11.0.0`](https://npmjs.com/package/restify)
       - [`webpack@5.75.0`](https://npmjs.com/package/webpack)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.14.8",
-        "botframework-streaming": "4.14.1",
+        "botframework-streaming": "4.20.0-dev.20230209.fbd66a2",
         "buffer": "6.0.3",
         "core-js": "3.15.2",
         "cross-fetch": "^3.1.5",
@@ -4377,9 +4377,9 @@
       "dev": true
     },
     "node_modules/botframework-streaming": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.14.1.tgz",
-      "integrity": "sha512-x5J9CB/PbKieJroPDy0qgwx7l6s9djkIxW7nSfq4neqKpquPJe+tukw2heINvXZWGkL3OXlaHTXVJRaRsoyNRQ==",
+      "version": "4.20.0-dev.20230209.fbd66a2",
+      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.20.0-dev.20230209.fbd66a2.tgz",
+      "integrity": "sha512-dtKk6zfwG7DCi7chLCMYm7RUaaLxhuBZildE0HpHQpGDgzHE8XthwRMnqYFgfY6+upU2RR/12hNvDs4YqP66NA==",
       "dependencies": {
         "@types/node": "^10.17.27",
         "@types/ws": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "7.14.8",
-    "botframework-streaming": "4.14.1",
+    "botframework-streaming": "4.20.0-dev.20230209.fbd66a2",
     "buffer": "6.0.3",
     "core-js": "3.15.2",
     "cross-fetch": "^3.1.5",


### PR DESCRIPTION
### Changed

- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#390](https://github.com/microsoft/BotFramework-DirectLineJS/pull/390) and [#388](https://github.com/microsoft/BotFramework-DirectLineJS/pull/388)
   - Production dependencies
      - [`botframework-streaming@4.20.0-dev.20230209.fbd66a2`](https://npmjs.com/package/botframework-streaming)