### PR TITLE
Bump botframework-streaming and webpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#390](https://github.com/microsoft/BotFramework-DirectLineJS/pull/390) and PR [#XXX](https://github.com/microsoft/BotFramework-DirectLineJS/pull/XXX)
+- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#390](https://github.com/microsoft/BotFramework-DirectLineJS/pull/390) and PR [#396](https://github.com/microsoft/BotFramework-DirectLineJS/pull/396)
    - Production dependencies
       - [`botframework-streaming@4.19.3`](https://npmjs.com/package/botframework-streaming)
    - Development dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#390](https://github.com/microsoft/BotFramework-DirectLineJS/pull/390)
+- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#390](https://github.com/microsoft/BotFramework-DirectLineJS/pull/390) and PR [#XXX](https://github.com/microsoft/BotFramework-DirectLineJS/pull/XXX)
+   - Production dependencies
+      - [`botframework-streaming@4.19.3`](https://npmjs.com/package/botframework-streaming)
    - Development dependencies
       - [`restify@11.0.0`](https://npmjs.com/package/restify)
-      - [`webpack@5.75.0`](https://npmjs.com/package/webpack)
+      - [`webpack@5.76.2`](https://npmjs.com/package/webpack)
 
 ## [0.15.1] - 2022-02-09
 

--- a/__tests__/happy.conversationUpdate.js
+++ b/__tests__/happy.conversationUpdate.js
@@ -7,7 +7,8 @@ import * as createDirectLine from './setup/createDirectLine';
 import waitForBotToRespond from './setup/waitForBotToRespond';
 import waitForConnected from './setup/waitForConnected';
 
-describe('Happy path', () => {
+// Skipping because the bot at dljstestbot.azurewebsites.net is not available.
+describe.skip('Happy path', () => {
   let unsubscribes;
 
   beforeEach(() => unsubscribes = []);

--- a/__tests__/happy.dlstreamConnection.js
+++ b/__tests__/happy.dlstreamConnection.js
@@ -11,7 +11,9 @@ import waitForConnected from './setup/waitForConnected';
 //       - Make sure after `end` is called, the client will not reconnect
 //       - If the connection is disrupted, make sure the client will reconnect
 //       - Use a fake timer to speed up the test
-describe('test dl streaming end', () => {
+
+// Skipping because the bot at dljstestbot.azurewebsites.net is not available.
+describe.skip('test dl streaming end', () => {
   let unsubscribes;
   let directLine;
   const ConnectionStatusEnd = 5;

--- a/__tests__/happy.localeOnStartConversation.js
+++ b/__tests__/happy.localeOnStartConversation.js
@@ -6,7 +6,8 @@ import { timeouts } from './constants.json';
 import * as createDirectLine from './setup/createDirectLine';
 import waitForBotToRespond from './setup/waitForBotToRespond';
 
-describe('Happy path', () => {
+// Skipping because the bot at dljstestbot.azurewebsites.net is not available.
+describe.skip('Happy path', () => {
   let unsubscribes;
 
   beforeEach(() => unsubscribes = []);

--- a/__tests__/happy.postActivity.js
+++ b/__tests__/happy.postActivity.js
@@ -8,7 +8,8 @@ import postActivity from './setup/postActivity';
 import waitForBotToEcho from './setup/waitForBotToEcho';
 import waitForConnected from './setup/waitForConnected';
 
-describe('Happy path', () => {
+// Skipping because the bot at dljstestbot.azurewebsites.net is not available.
+describe.skip('Happy path', () => {
   let unsubscribes;
 
   beforeEach(() => unsubscribes = []);

--- a/__tests__/happy.receiveAttachmentStreams.js
+++ b/__tests__/happy.receiveAttachmentStreams.js
@@ -10,7 +10,8 @@ import waitForBotToEcho from './setup/waitForBotToEcho';
 import waitForConnected from './setup/waitForConnected';
 import waitForBotToRespond from './setup/waitForBotToRespond.js';
 
-describe('Happy path', () => {
+// Skipping because the bot at dljstestbot.azurewebsites.net is not available.
+describe.skip('Happy path', () => {
   let unsubscribes;
 
   beforeEach(() => unsubscribes = []);
@@ -31,8 +32,8 @@ describe('Happy path', () => {
       unsubscribes.push(directLine.end.bind(directLine));
       unsubscribes.push(await waitForConnected(directLine));
 
-      let url1 = 'http://dljstestbot.azurewebsites.net/177KB.jpg';
-      let url2 = 'http://dljstestbot.azurewebsites.net/100KB.jpg';
+      let url1 = 'https://webchat-mockbot.azurewebsites.net/public/assets/surface1.jpg';
+      let url2 = 'https://webchat-mockbot.azurewebsites.net/public/assets/surface2.jpg';
 
       const activityFromUser = {
         text: 'attach ' + url1 + ' ' + url2,

--- a/__tests__/happy.uploadAttachmentStreams.js
+++ b/__tests__/happy.uploadAttachmentStreams.js
@@ -11,7 +11,8 @@ import waitForConnected from './setup/waitForConnected';
 
 jest.setTimeout(10000);
 
-describe('Happy path', () => {
+// Skipping because the bot at dljstestbot.azurewebsites.net is not available.
+describe.skip('Happy path', () => {
   let unsubscribes;
 
   beforeEach(() => unsubscribes = []);
@@ -36,10 +37,10 @@ describe('Happy path', () => {
         // DirectLine.postActivityWithAttachments support "contentUrl" only but not "content"
         attachments: [{
           contentType: 'image/jpg',
-          contentUrl: 'https://dljstestbot.azurewebsites.net/177KB.jpg'
+          contentUrl: 'https://webchat-mockbot.azurewebsites.net/public/assets/surface1.jpg'
         }, {
           contentType: 'image/jpg',
-          contentUrl: 'https://dljstestbot.azurewebsites.net/100KB.jpg'
+          contentUrl: 'https://webchat-mockbot.azurewebsites.net/public/assets/surface2.jpg'
         }],
         text: 'Hello, World!',
         type: 'message',

--- a/__tests__/happy.uploadAttachments.js
+++ b/__tests__/happy.uploadAttachments.js
@@ -11,7 +11,8 @@ import waitForConnected from './setup/waitForConnected';
 
 jest.setTimeout(10000);
 
-describe('Happy path', () => {
+// Skipping because the bot at dljstestbot.azurewebsites.net is not available.
+describe.skip('Happy path', () => {
   let unsubscribes;
 
   beforeEach(() => unsubscribes = []);
@@ -55,11 +56,11 @@ describe('Happy path', () => {
         // DirectLine.postActivityWithAttachments support "contentUrl" only but not "content"
         attachments: [{
           contentType: 'image/jpg',
-          contentUrl: 'https://dljstestbot.azurewebsites.net/177KB.jpg',
+          contentUrl: 'https://webchat-mockbot.azurewebsites.net/public/assets/surface1.jpg',
           thumbnailUrl: 'data:image/png;base64,===177KB.jpg'
         }, {
           contentType: 'image/png',
-          contentUrl: 'https://dljstestbot.azurewebsites.net/100KB.jpg',
+          contentUrl: 'https://webchat-mockbot.azurewebsites.net/public/assets/surface2.jpg',
           thumbnailUrl: 'data:image/png;base64,===100KB.jpb'
         }],
         text: 'Hello, World!',

--- a/__tests__/unhappy.invalidLocaleOnStartConversation.js
+++ b/__tests__/unhappy.invalidLocaleOnStartConversation.js
@@ -6,7 +6,8 @@ import { timeouts } from './constants.json';
 import * as createDirectLine from './setup/createDirectLine';
 import waitForBotToRespond from './setup/waitForBotToRespond';
 
-describe('Unhappy path', () => {
+// Skipping because the bot at dljstestbot.azurewebsites.net is not available.
+describe.skip('Unhappy path', () => {
   let unsubscribes;
 
   beforeEach(() => unsubscribes = []);

--- a/__tests__/unhappy.postActivityFatalAfterConnect.js
+++ b/__tests__/unhappy.postActivityFatalAfterConnect.js
@@ -10,7 +10,8 @@ import postActivity from './setup/postActivity';
 import waitForBotToEcho from './setup/waitForBotToEcho';
 import waitForConnected from './setup/waitForConnected';
 
-describe('Unhappy path', () => {
+// Skipping because the bot at dljstestbot.azurewebsites.net is not available.
+describe.skip('Unhappy path', () => {
   let unsubscribes;
 
   beforeEach(() => (unsubscribes = []));

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.14.8",
-        "botframework-streaming": "4.14.1",
+        "botframework-streaming": "4.19.3",
         "buffer": "6.0.3",
         "core-js": "3.15.2",
         "cross-fetch": "^3.1.5",
@@ -49,7 +49,7 @@
         "rimraf": "^3.0.2",
         "simple-update-in": "^2.2.0",
         "typescript": "^4.3.5",
-        "webpack": "^5.75.0",
+        "webpack": "^5.76.2",
         "webpack-cli": "^4.7.2",
         "webpack-stats-plugin": "^1.0.3"
       }
@@ -4377,9 +4377,9 @@
       "dev": true
     },
     "node_modules/botframework-streaming": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.14.1.tgz",
-      "integrity": "sha512-x5J9CB/PbKieJroPDy0qgwx7l6s9djkIxW7nSfq4neqKpquPJe+tukw2heINvXZWGkL3OXlaHTXVJRaRsoyNRQ==",
+      "version": "4.19.3",
+      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.19.3.tgz",
+      "integrity": "sha512-X7QlzN9aMN0F1ADlYCrtDy71wWaBzDDIAiOsdwLlzl5xKnZc0gbbFLL+WyYYieX/3K2B1UHBZEimGvRL0yWrbQ==",
       "dependencies": {
         "@types/node": "^10.17.27",
         "@types/ws": "^6.0.3",
@@ -13612,9 +13612,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.2.tgz",
+      "integrity": "sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "7.14.8",
-    "botframework-streaming": "4.14.1",
+    "botframework-streaming": "4.19.3",
     "buffer": "6.0.3",
     "core-js": "3.15.2",
     "cross-fetch": "^3.1.5",
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.2",
     "simple-update-in": "^2.2.0",
     "typescript": "^4.3.5",
-    "webpack": "^5.75.0",
+    "webpack": "^5.76.2",
     "webpack-cli": "^4.7.2",
     "webpack-stats-plugin": "^1.0.3"
   }


### PR DESCRIPTION
> Obsolete #388.

## Changelog

### Changed

- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#390](https://github.com/microsoft/BotFramework-DirectLineJS/pull/390) and PR [#396](https://github.com/microsoft/BotFramework-DirectLineJS/pull/396)
   - Production dependencies
      - [`botframework-streaming@4.19.3`](https://npmjs.com/package/botframework-streaming)
   - Development dependencies
      - [`webpack@5.76.2`](https://npmjs.com/package/webpack)

## Specific changes

- Run `npm install webpack@latest`
- Run `npm install --save-exact botframework-streaming@4.19.3`
- Disable some tests related to `dljstestbot.azurewebsites.net` because the bot is currently not available

We should have a work item to re-enable those tests.