### PR TITLE
Catch all async calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed [#398](https://github.com/microsoft/BotFramework-DirectLineJS/issues/398). In `DirectLineStreaming`, all calls to async function should be caught and rethrow appropriately, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-DirectLineJS/pull/XXX)
+
 ## [0.15.2] - 2023-03-21
 
 ### Changed


### PR DESCRIPTION
## Description

All calls to async functions must be caught and rethrow when needed.

Otherwise, if the rejection is not handled and control is back to Node.js event loop, it will throw `unhandledRejection` and terminate the process.

## Changelog

### Fixed

- Fixed [#398](https://github.com/microsoft/BotFramework-DirectLineJS/issues/398). In `DirectLineStreaming`, all calls to async function should be caught and rethrow appropriately, by [@compulim](https://github.com/compulim) in PR [#XXX](https://github.com/microsoft/BotFramework-DirectLineJS/pull/XXX)