### PR TITLE
Bump to 0.15.4-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.15.3] - 2023-06-05
+
 ### Fixed
 
 - Fixed [#398](https://github.com/microsoft/BotFramework-DirectLineJS/issues/398). In `DirectLineStreaming`, all calls to async function should be caught and rethrow appropriately, by [@compulim](https://github.com/compulim) in PR [#399](https://github.com/microsoft/BotFramework-DirectLineJS/pull/399)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.15.3-0",
+  "version": "0.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "botframework-directlinejs",
-      "version": "0.15.3-0",
+      "version": "0.15.3",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.14.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.15.3",
+  "version": "0.15.4-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "botframework-directlinejs",
-      "version": "0.15.3",
+      "version": "0.15.4-0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.14.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.15.3",
+  "version": "0.15.4-0",
   "description": "Client library for the Microsoft Bot Framework Direct Line 3.0 protocol",
   "files": [
     "dist/**/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.15.3-0",
+  "version": "0.15.3",
   "description": "Client library for the Microsoft Bot Framework Direct Line 3.0 protocol",
   "files": [
     "dist/**/*",


### PR DESCRIPTION
Bump to 0.15.4-0 after [release of 0.15.3](https://github.com/microsoft/BotFramework-DirectLineJS/releases/tag/v0.15.3).