### PR TITLE
Bump botframework-streaming@4.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#406](https://github.com/microsoft/BotFramework-DirectLineJS/pull/406)
+   - Production dependencies
+      - [`botframework-streaming@4.20.0`](https://npmjs.com/package/botframework-streaming)
+
 ## [0.15.3] - 2023-06-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.14.8",
-        "botframework-streaming": "4.20.0-ww.20230425",
+        "botframework-streaming": "4.20.0",
         "buffer": "6.0.3",
         "core-js": "3.15.2",
         "cross-fetch": "^3.1.5",
@@ -4256,9 +4256,9 @@
       "dev": true
     },
     "node_modules/botframework-streaming": {
-      "version": "4.20.0-ww.20230425",
-      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.20.0-ww.20230425.tgz",
-      "integrity": "sha512-bSno/q5BQwtICtUMatEMTOt6nB41GR7GGvWlOizWNTOA5bTkswTquAzZkeUXDHhvhx9cK7bVvxzdf7Pduxd18Q==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.20.0.tgz",
+      "integrity": "sha512-yPH9+BYJ9RPb76OcARjls3QHfwRejNQz9RxR9YXt6OX0nMfP+sdMfE8BYTDqvBiIXLivbPi+pJG334PwskfohA==",
       "dependencies": {
         "@types/node": "^10.17.27",
         "@types/ws": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "7.14.8",
-    "botframework-streaming": "4.20.0-ww.20230425",
+    "botframework-streaming": "4.20.0",
     "buffer": "6.0.3",
     "core-js": "3.15.2",
     "cross-fetch": "^3.1.5",


### PR DESCRIPTION
## Changelog

### Changed

- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#406](https://github.com/microsoft/BotFramework-DirectLineJS/pull/406)
   - Production dependencies
      - [`botframework-streaming@4.20.0`](https://npmjs.com/package/botframework-streaming)

## Specific changes

- `npm install botframework-streaming@latest --save-exact`