### PR TITLE
Bump to 0.15.7-0

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   build-and-draft:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -72,6 +72,8 @@ jobs:
     needs:
       - build-and-draft
       - publish-package
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Bumped dependencies, by [@compulim](https://github.com/compulim), in PR [#426](https://github.com/microsoft/BotFramework-DirectLineJS/pull/426)
+- Bumped dependencies, in PR [#426](https://github.com/microsoft/BotFramework-DirectLineJS/pull/426) and [#438](https://github.com/microsoft/BotFramework-DirectLineJS/pull/438)
    - Production dependencies
       - [`botframework-streaming@4.23.0`](https://npmjs.com/package/botframework-streaming)
+      - [`@babel/runtime@7.26.10`](https://npmjs.com/package/@babel/runtime)
 
 ## [0.15.5] - 2023-10-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.15.6] - 2025-04-17
+
 ### Changed
 
 - Bumped dependencies, in PR [#426](https://github.com/microsoft/BotFramework-DirectLineJS/pull/426) and [#438](https://github.com/microsoft/BotFramework-DirectLineJS/pull/438)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.15.6-0",
+  "version": "0.15.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "botframework-directlinejs",
-      "version": "0.15.6-0",
+      "version": "0.15.6",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.26.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.15.6",
+  "version": "0.15.7-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "botframework-directlinejs",
-      "version": "0.15.6",
+      "version": "0.15.7-0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.26.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.15.6",
+  "version": "0.15.7-0",
   "description": "Client library for the Microsoft Bot Framework Direct Line 3.0 protocol",
   "files": [
     "dist/**/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.15.6-0",
+  "version": "0.15.6",
   "description": "Client library for the Microsoft Bot Framework Direct Line 3.0 protocol",
   "files": [
     "dist/**/*",


### PR DESCRIPTION
Bump to 0.15.7-0 after release of 0.15.6.

Also updated some CI pipelines as we now requires to define permissions explicitly.