### PR TITLE
Fix uppercase in repository.url

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/BotFramework-DirectLineJS.git"
+    "url": "https://github.com/Microsoft/BotFramework-DirectLineJS"
   },
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Microsoft/BotFramework-DirectLineJS"
+    "url": "https://github.com/microsoft/BotFramework-DirectLineJS.git"
   },
   "author": "Microsoft Corporation",
   "license": "MIT",


### PR DESCRIPTION
Resolving `npm publish` error. Not sure why npm added `git+` but verified no `git+` in `package.json`.

`422 Unprocessable Entity - PUT https://registry.npmjs.org/botframework-directlinejs - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/Microsoft/BotFramework-DirectLineJS.git", expected to match "https://github.com/microsoft/BotFramework-DirectLineJS" from provenance
`