### PR TITLE
Bump to 0.15.10-0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.15.9",
+  "version": "0.15.10-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "botframework-directlinejs",
-      "version": "0.15.9",
+      "version": "0.15.10-0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.15.9",
+  "version": "0.15.10-0",
   "description": "Client library for the Microsoft Bot Framework Direct Line 3.0 protocol",
   "files": [
     "dist/**/*",


### PR DESCRIPTION
- `npm version prepatch --no-git-tag-version`