### PR TITLE
Prepare to release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-18
+
 ### Changed
 
 - 👷🏻 Bumped GitHub Actions in CI/CD workflows, by [@orgads](https://github.com/orgads), in PR [#453](https://github.com/microsoft/BotFramework-DirectLineJS/pull/453)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.15.10-0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "botframework-directlinejs",
-      "version": "0.15.10-0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botframework-directlinejs",
-  "version": "0.15.10-0",
+  "version": "0.16.0",
   "description": "Client library for the Microsoft Bot Framework Direct Line 3.0 protocol",
   "files": [
     "dist/**/*",


### PR DESCRIPTION
- `npm version 0.16.0 --no-git-tag-version`